### PR TITLE
Added `layergroup`, `daynight`, `track` flags. Added orbit descriptions.

### DIFF
--- a/common/config/metadata/reference/orbits/Aqua_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Aqua_Orbit_Asc.md
@@ -1,4 +1,4 @@
 # Orbital Track (Ascending/Day) Aqua
-Orbital Track (Ascending/Day) Aqua layer is the path of the Aqua satellite on its ascending/day-time orbit. Local overpass time at the equator is normally 13:30.
+Orbital Track (Ascending/Day) Aqua layer is the path of the Aqua satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Aqua_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Aqua_Orbit_Asc.md
@@ -1,0 +1,4 @@
+# Orbital Track (Ascending/Day) Aqua
+Orbital Track (Ascending/Day) Aqua layer is the path of the Aqua satellite on its ascending/day-time orbit. Local overpass time at the equator is normally 13:30.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Aqua_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Aqua_Orbit_Dsc.md
@@ -1,0 +1,4 @@
+# Orbital Track (Descending/Night) Aqua
+Orbital Track (Descending/Day) Aqua layer is the path of the Aqua satellite on its ascending/night-time orbit. Local overpass time at the equator is normally 01:30.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Aqua_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Aqua_Orbit_Dsc.md
@@ -1,4 +1,4 @@
 # Orbital Track (Descending/Night) Aqua
-Orbital Track (Descending/Day) Aqua layer is the path of the Aqua satellite on its ascending/night-time orbit. Local overpass time at the equator is normally 01:30.
+Orbital Track (Descending/Day) Aqua layer is the path of the Aqua satellite on its ascending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Aura_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Aura_Orbit_Asc.md
@@ -1,4 +1,4 @@
 # Orbital Track (Ascending/Day) Aura
-Orbital Track (Ascending/Day) Aura layer is the path of the Aura satellite on its ascending/day-time orbit. Local overpass time at the equator is normally 13:30.
+Orbital Track (Ascending/Day) Aura layer is the path of the Aura satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Aura_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Aura_Orbit_Asc.md
@@ -1,0 +1,4 @@
+# Orbital Track (Ascending/Day) Aura
+Orbital Track (Ascending/Day) Aura layer is the path of the Aura satellite on its ascending/day-time orbit. Local overpass time at the equator is normally 13:30.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Aura_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Aura_Orbit_Dsc.md
@@ -1,0 +1,4 @@
+# Orbital Track (Descending/Night) Aura
+Orbital Track (Descending/Night) Aura layer is the path of the Aura satellite on its ascending/night-time orbit. Local overpass time at the equator is normally 01:30.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Aura_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Aura_Orbit_Dsc.md
@@ -1,4 +1,4 @@
 # Orbital Track (Descending/Night) Aura
-Orbital Track (Descending/Night) Aura layer is the path of the Aura satellite on its ascending/night-time orbit. Local overpass time at the equator is normally 01:30.
+Orbital Track (Descending/Night) Aura layer is the path of the Aura satellite on its ascending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Calipso_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Calipso_Orbit_Asc.md
@@ -1,4 +1,4 @@
 # Orbital Track (Ascending/Day) CALIPSO
-Orbital Track (Ascending/Day)  CALIPSO layer is the path of the  Cloud-Aerosol Lidar and Infrared Pathfinder Satellite Observation (CALIPSO) satellite on its ascending/day-time orbit. Local overpass time at the equator is normally 13:30.
+Orbital Track (Ascending/Day)  CALIPSO layer is the path of the  Cloud-Aerosol Lidar and Infrared Pathfinder Satellite Observation (CALIPSO) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Calipso_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Calipso_Orbit_Asc.md
@@ -1,0 +1,4 @@
+# Orbital Track (Ascending/Day) CALIPSO
+Orbital Track (Ascending/Day)  CALIPSO layer is the path of the  Cloud-Aerosol Lidar and Infrared Pathfinder Satellite Observation (CALIPSO) satellite on its ascending/day-time orbit. Local overpass time at the equator is normally 13:30.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Calipso_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Calipso_Orbit_Dsc.md
@@ -1,4 +1,4 @@
 # Orbital Track (Descending/Night) CALIPSO
-Orbital Track (Descending/Night) CALIPSO layer is the path of the  Cloud-Aerosol Lidar and Infrared Pathfinder Satellite Observation  (CALIPSO) satellite on its descending/night-time orbit. Local overpass time at the equator is normally 01:30.
+Orbital Track (Descending/Night) CALIPSO layer is the path of the  Cloud-Aerosol Lidar and Infrared Pathfinder Satellite Observation  (CALIPSO) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Calipso_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Calipso_Orbit_Dsc.md
@@ -1,0 +1,4 @@
+# Orbital Track (Descending/Night) CALIPSO
+Orbital Track (Descending/Night) CALIPSO layer is the path of the  Cloud-Aerosol Lidar and Infrared Pathfinder Satellite Observation  (CALIPSO) satellite on its descending/night-time orbit. Local overpass time at the equator is normally 01:30.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/GCOM_W1_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/GCOM_W1_Orbit_Asc.md
@@ -1,4 +1,4 @@
 # Orbital Track (Ascending/Day) GCOM-W1
-Orbital Track (Ascending/Day) GCOM-W1 layer is the path of the Global Change Observation Mission - Water 1 “Shizuku” (GCOM-W1) satellite on its ascending/day-time orbit. Local overpass time at the equator is normally 13:30.
+Orbital Track (Ascending/Day) GCOM-W1 layer is the path of the Global Change Observation Mission - Water 1 “Shizuku” (GCOM-W1) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/GCOM_W1_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/GCOM_W1_Orbit_Asc.md
@@ -1,0 +1,4 @@
+# Orbital Track (Ascending/Day) GCOM-W1
+Orbital Track (Ascending/Day) GCOM-W1 layer is the path of the Global Change Observation Mission - Water 1 “Shizuku” (GCOM-W1) satellite on its ascending/day-time orbit. Local overpass time at the equator is normally 13:30.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/GCOM_W1_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/GCOM_W1_Orbit_Dsc.md
@@ -1,4 +1,4 @@
 # Orbital Track (Descending/Night) GCOM-W1
-Orbital Track (Descending/Night) GCOM-W1 layer is the path of the Global Change Observation Mission - Water 1 “Shizuku” (GCOM-W1) satellite on its descending/night-time orbit. Local overpass time at the equator is normally 01:30.
+Orbital Track (Descending/Night) GCOM-W1 layer is the path of the Global Change Observation Mission - Water 1 “Shizuku” (GCOM-W1) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/GCOM_W1_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/GCOM_W1_Orbit_Dsc.md
@@ -1,0 +1,4 @@
+# Orbital Track (Descending/Night) GCOM-W1
+Orbital Track (Descending/Night) GCOM-W1 layer is the path of the Global Change Observation Mission - Water 1 “Shizuku” (GCOM-W1) satellite on its descending/night-time orbit. Local overpass time at the equator is normally 01:30.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/GPM_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/GPM_Orbit_Asc.md
@@ -1,0 +1,4 @@
+# Orbital Track (Ascending/Day) GPM
+Orbital Track (Ascending/Day) GPM layer is the path of the Global Precipitation Measurement (GPM) core observatory on its ascending/day-time orbit.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/GPM_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/GPM_Orbit_Asc.md
@@ -1,4 +1,4 @@
 # Orbital Track (Ascending/Day) GPM
-Orbital Track (Ascending/Day) GPM layer is the path of the Global Precipitation Measurement (GPM) core observatory on its ascending/day-time orbit.
+Orbital Track (Ascending/Day) GPM layer is the path of the Global Precipitation Measurement (GPM) core observatory on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC).
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/GPM_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/GPM_Orbit_Dsc.md
@@ -1,4 +1,4 @@
 # Orbital Track (Descending/Day) GPM
-Orbital Track (Descending/Day) GPM layer is the path of the Global Precipitation Measurement (GPM) core observatory on its descending/day orbit.
+Orbital Track (Descending/Day) GPM layer is the path of the Global Precipitation Measurement (GPM) core observatory on its descending/day orbit. Orbit Track times are shown in Coordinated Universal Time (UTC).
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/GPM_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/GPM_Orbit_Dsc.md
@@ -1,0 +1,4 @@
+# Orbital Track (Descending/Day) GPM
+Orbital Track (Descending/Day) GPM layer is the path of the Global Precipitation Measurement (GPM) core observatory on its descending/day orbit.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Suomi_NPP_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Suomi_NPP_Orbit_Asc.md
@@ -1,4 +1,4 @@
 # Orbital Track (Ascending/Day) Suomi NPP
-Orbital Track (Ascending/Day) Suomi NPP layer is the path of the Suomi National Polar-orbiting Partnership (NPP) satellite on its ascending/day-time orbit. Local overpass time at the equator is approximately 13:30.
+Orbital Track (Ascending/Day) Suomi NPP layer is the path of the Suomi National Polar-orbiting Partnership (NPP) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is approximately 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Suomi_NPP_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Suomi_NPP_Orbit_Asc.md
@@ -1,0 +1,4 @@
+# Orbital Track (Ascending/Day) Suomi NPP
+Orbital Track (Ascending/Day) Suomi NPP layer is the path of the Suomi National Polar-orbiting Partnership (NPP) satellite on its ascending/day-time orbit. Local overpass time at the equator is approximately 13:30.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Suomi_NPP_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Suomi_NPP_Orbit_Dsc.md
@@ -1,4 +1,4 @@
 # Orbital Track (Descending/Night) Suomi NPP
-Orbital Track (Descending/Night) Suomi NPP layer is the path of the Suomi National Polar-orbiting Partnership (NPP) satellite on its descending/night-time orbit. Local overpass time at the equator is approximately 01:30.
+Orbital Track (Descending/Night) Suomi NPP layer is the path of the Suomi National Polar-orbiting Partnership (NPP) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is approximately 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Suomi_NPP_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Suomi_NPP_Orbit_Dsc.md
@@ -1,0 +1,4 @@
+# Orbital Track (Descending/Night) Suomi NPP
+Orbital Track (Descending/Night) Suomi NPP layer is the path of the Suomi National Polar-orbiting Partnership (NPP) satellite on its descending/night-time orbit. Local overpass time at the equator is approximately 01:30.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Terra_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Terra_Orbit_Asc.md
@@ -1,0 +1,4 @@
+# Orbital Track (Ascending/Night) Terra
+Orbital Track (Ascending/Night) Terra layer is the path of the Terra satellite on its ascending/night-time orbit. Local overpass time at the equator is normally 22:30.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Terra_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Terra_Orbit_Asc.md
@@ -1,4 +1,4 @@
 # Orbital Track (Ascending/Night) Terra
-Orbital Track (Ascending/Night) Terra layer is the path of the Terra satellite on its ascending/night-time orbit. Local overpass time at the equator is normally 22:30.
+Orbital Track (Ascending/Night) Terra layer is the path of the Terra satellite on its ascending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 22:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Terra_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Terra_Orbit_Dsc.md
@@ -1,0 +1,4 @@
+# Orbital Track (Descending/Day) Terra
+Orbital Track (Descending/Day) Terra layer is the path of the Terra satellite on its descending/day-time orbit. Local overpass time at the equator is normally 10:30.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Terra_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Terra_Orbit_Dsc.md
@@ -1,4 +1,4 @@
 # Orbital Track (Descending/Day) Terra
-Orbital Track (Descending/Day) Terra layer is the path of the Terra satellite on its descending/day-time orbit. Local overpass time at the equator is normally 10:30.
+Orbital Track (Descending/Day) Terra layer is the path of the Terra satellite on its descending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 10:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/wv.json/layers/airs/AIRS_CO_Total_Column_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_CO_Total_Column_Day.json
@@ -7,9 +7,7 @@
             "tags":     "co",
             "group":    "overlays",
             "product":  "AIRX2RET_DAY",
-            "layergroup": [
-              "airs"
-            ],
+            
             "layergroup": [
               "airs"
             ],

--- a/common/config/wv.json/layers/airs/AIRS_CO_Total_Column_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_CO_Total_Column_Day.json
@@ -7,7 +7,12 @@
             "tags":     "co",
             "group":    "overlays",
             "product":  "AIRX2RET_DAY",
-
+            "layergroup": [
+              "airs"
+            ],
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "recommended": ["red_1"]
             }

--- a/common/config/wv.json/layers/airs/AIRS_CO_Total_Column_Night.json
+++ b/common/config/wv.json/layers/airs/AIRS_CO_Total_Column_Night.json
@@ -8,6 +8,9 @@
             "group":    "overlays",
             "product":  "AIRX2RET_NIGHT",
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "recommended": ["red_1"]
             }

--- a/common/config/wv.json/layers/airs/AIRS_Dust_Score.json
+++ b/common/config/wv.json/layers/airs/AIRS_Dust_Score.json
@@ -7,6 +7,9 @@
             "group":    "overlays",
             "product":  "AIRIBQAP",
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "exclude":  ["orange_1"]
             }

--- a/common/config/wv.json/layers/airs/AIRS_Dust_Score_Ocean_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_Dust_Score_Ocean_Day.json
@@ -7,6 +7,9 @@
             "group":    "overlays",
             "product":  "AIRIBQAP",
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "exclude":  ["orange_1"]
             }

--- a/common/config/wv.json/layers/airs/AIRS_Dust_Score_Ocean_Night.json
+++ b/common/config/wv.json/layers/airs/AIRS_Dust_Score_Ocean_Night.json
@@ -7,6 +7,9 @@
             "group":    "overlays",
             "product":  "AIRIBQAP",
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "exclude":  ["orange_1"]
             }

--- a/common/config/wv.json/layers/airs/AIRS_Prata_SO2_Index_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_Prata_SO2_Index_Day.json
@@ -8,6 +8,9 @@
             "group":    "overlays",
             "product":  "AIRIBRAD_DAY",
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "recommended": ["orange_1", "red_1"]
             }

--- a/common/config/wv.json/layers/airs/AIRS_Prata_SO2_Index_Night.json
+++ b/common/config/wv.json/layers/airs/AIRS_Prata_SO2_Index_Night.json
@@ -8,6 +8,9 @@
             "group":    "overlays",
             "product":  "AIRIBRAD_NIGHT",
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "recommended": ["orange_1", "red_1"]
             }

--- a/common/config/wv.json/layers/airs/AIRS_Precipitation_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_Precipitation_Day.json
@@ -8,6 +8,9 @@
             "group":    "overlays",
             "product":  "AIRX2SUP_DAY",
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "recommended": ["blue_1", "blue_3"]
             }

--- a/common/config/wv.json/layers/airs/AIRS_Precipitation_Night.json
+++ b/common/config/wv.json/layers/airs/AIRS_Precipitation_Night.json
@@ -8,6 +8,9 @@
             "group":    "overlays",
             "product":  "AIRX2SUP_NIGHT",
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "recommended": ["blue_1", "blue_3"]
             }

--- a/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_400hPa_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_400hPa_Day.json
@@ -22,6 +22,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id": "AIRS_RelativeHumidity_400hPa_Day"
             }

--- a/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_400hPa_Night.json
+++ b/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_400hPa_Night.json
@@ -22,6 +22,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id": "AIRS_RelativeHumidity_400hPa_Night"
             }

--- a/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_500hPa_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_500hPa_Day.json
@@ -22,6 +22,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id": "AIRS_RelativeHumidity_500hPa_Day"
             }

--- a/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_500hPa_Night.json
+++ b/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_500hPa_Night.json
@@ -22,6 +22,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id": "AIRS_RelativeHumidity_500hPa_Night"
             }

--- a/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_600hPa_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_600hPa_Day.json
@@ -22,6 +22,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id": "AIRS_RelativeHumidity_600hPa_Day"
             }

--- a/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_600hPa_Night.json
+++ b/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_600hPa_Night.json
@@ -22,6 +22,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id": "AIRS_RelativeHumidity_600hPa_Night"
             }

--- a/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_700hPa_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_700hPa_Day.json
@@ -22,6 +22,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id": "AIRS_RelativeHumidity_700hPa_Day"
             }

--- a/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_700hPa_Night.json
+++ b/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_700hPa_Night.json
@@ -22,6 +22,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id": "AIRS_RelativeHumidity_700hPa_Night"
             }

--- a/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_850hPa_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_850hPa_Day.json
@@ -22,6 +22,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id": "AIRS_RelativeHumidity_850hPa_Day"
             }

--- a/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_850hPa_Night.json
+++ b/common/config/wv.json/layers/airs/AIRS_RelativeHumidity_850hPa_Night.json
@@ -22,6 +22,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id": "AIRS_RelativeHumidity_850hPa_Night"
             }

--- a/common/config/wv.json/layers/airs/AIRS_Temperature_400hPa_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_Temperature_400hPa_Day.json
@@ -21,6 +21,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id":   "AIRS_Temperature_400hPa_Day"
             }

--- a/common/config/wv.json/layers/airs/AIRS_Temperature_400hPa_Night.json
+++ b/common/config/wv.json/layers/airs/AIRS_Temperature_400hPa_Night.json
@@ -21,6 +21,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id":   "AIRS_Temperature_400hPa_Night"
             }

--- a/common/config/wv.json/layers/airs/AIRS_Temperature_500hPa_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_Temperature_500hPa_Day.json
@@ -21,6 +21,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id":   "AIRS_Temperature_500hPa_Day"
             }

--- a/common/config/wv.json/layers/airs/AIRS_Temperature_500hPa_Night.json
+++ b/common/config/wv.json/layers/airs/AIRS_Temperature_500hPa_Night.json
@@ -21,6 +21,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id":   "AIRS_Temperature_500hPa_Night"
             }

--- a/common/config/wv.json/layers/airs/AIRS_Temperature_600hPa_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_Temperature_600hPa_Day.json
@@ -21,6 +21,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id":   "AIRS_Temperature_600hPa_Day"
             }

--- a/common/config/wv.json/layers/airs/AIRS_Temperature_600hPa_Night.json
+++ b/common/config/wv.json/layers/airs/AIRS_Temperature_600hPa_Night.json
@@ -21,6 +21,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id":   "AIRS_Temperature_600hPa_Night"
             }

--- a/common/config/wv.json/layers/airs/AIRS_Temperature_700hPa_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_Temperature_700hPa_Day.json
@@ -21,6 +21,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id":   "AIRS_Temperature_700hPa_Day"
             }

--- a/common/config/wv.json/layers/airs/AIRS_Temperature_700hPa_Night.json
+++ b/common/config/wv.json/layers/airs/AIRS_Temperature_700hPa_Night.json
@@ -21,6 +21,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id":   "AIRS_Temperature_700hPa_Night"
             }

--- a/common/config/wv.json/layers/airs/AIRS_Temperature_850hPa_Day.json
+++ b/common/config/wv.json/layers/airs/AIRS_Temperature_850hPa_Day.json
@@ -21,6 +21,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id":   "AIRS_Temperature_850hPa_Day"
             }

--- a/common/config/wv.json/layers/airs/AIRS_Temperature_850hPa_Night.json
+++ b/common/config/wv.json/layers/airs/AIRS_Temperature_850hPa_Night.json
@@ -21,6 +21,9 @@
                 }
             },
 
+            "layergroup": [
+              "airs"
+            ],
             "palette": {
                 "id":   "AIRS_Temperature_850hPa_Night"
             }

--- a/common/config/wv.json/layers/amsr-e/AMSRE_Brightness_Temp_89H_Day.json
+++ b/common/config/wv.json/layers/amsr-e/AMSRE_Brightness_Temp_89H_Day.json
@@ -6,6 +6,9 @@
             "subtitle": "Aqua / AMSR-E",
             "group":    "overlays",
             "product":  "AE_L2A_DAY",
+            "layergroup": [
+              "amsr-e"
+            ],
             "inactive": true
         }
     }

--- a/common/config/wv.json/layers/amsr-e/AMSRE_Brightness_Temp_89H_Night.json
+++ b/common/config/wv.json/layers/amsr-e/AMSRE_Brightness_Temp_89H_Night.json
@@ -6,6 +6,9 @@
             "subtitle": "Aqua / AMSR-E",
             "group":    "overlays",
             "product":  "AE_L2A_NIGHT",
+            "layergroup": [
+              "amsr-e"
+            ],
             "inactive": true
         }
     }

--- a/common/config/wv.json/layers/amsr-e/AMSRE_Brightness_Temp_89V_Day.json
+++ b/common/config/wv.json/layers/amsr-e/AMSRE_Brightness_Temp_89V_Day.json
@@ -6,6 +6,9 @@
             "subtitle": "Aqua / AMSR-E",
             "group":    "overlays",
             "product":  "AE_L2A_DAY",
+            "layergroup": [
+              "amsr-e"
+            ],
             "inactive": true
         }
     }

--- a/common/config/wv.json/layers/amsr-e/AMSRE_Brightness_Temp_89V_Night.json
+++ b/common/config/wv.json/layers/amsr-e/AMSRE_Brightness_Temp_89V_Night.json
@@ -6,6 +6,9 @@
             "subtitle": "Aqua / AMSR-E",
             "group":    "overlays",
             "product":  "AE_L2A_NIGHT",
+            "layergroup": [
+              "amsr-e"
+            ],
             "inactive": true
         }
     }

--- a/common/config/wv.json/layers/amsr-e/AMSRE_Sea_Ice_Brightness_Temp_89H.json
+++ b/common/config/wv.json/layers/amsr-e/AMSRE_Sea_Ice_Brightness_Temp_89H.json
@@ -6,6 +6,9 @@
             "subtitle": "Aqua / AMSR-E",
             "group":    "overlays",
             "product":  "AE_SI6",
+            "layergroup": [
+              "amsr-e"
+            ],
             "inactive": true
         }
     }

--- a/common/config/wv.json/layers/amsr-e/AMSRE_Sea_Ice_Brightness_Temp_89V.json
+++ b/common/config/wv.json/layers/amsr-e/AMSRE_Sea_Ice_Brightness_Temp_89V.json
@@ -6,6 +6,9 @@
             "subtitle": "Aqua / AMSR-E",
             "group":    "overlays",
             "product":  "AE_SI6",
+            "layergroup": [
+              "amsr-e"
+            ],
             "inactive": true
         }
     }

--- a/common/config/wv.json/layers/amsr-e/AMSRE_Sea_Ice_Concentration_12km.json
+++ b/common/config/wv.json/layers/amsr-e/AMSRE_Sea_Ice_Concentration_12km.json
@@ -6,6 +6,9 @@
             "subtitle": "Aqua / AMSR-E",
             "group":    "overlays",
             "product":  "AE_SI12",
+            "layergroup": [
+              "amsr-e"
+            ],
             "inactive": true,
 
             "palette": {

--- a/common/config/wv.json/layers/amsr-e/AMSRE_Sea_Ice_Concentration_25km.json
+++ b/common/config/wv.json/layers/amsr-e/AMSRE_Sea_Ice_Concentration_25km.json
@@ -6,6 +6,9 @@
             "subtitle": "Aqua / AMSR-E",
             "group":    "overlays",
             "product":  "AE_SI25",
+            "layergroup": [
+              "amsr-e"
+            ],
             "inactive": true,
 
             "palette": {

--- a/common/config/wv.json/layers/amsr-e/AMSRE_Snow_Depth_Over_Ice.json
+++ b/common/config/wv.json/layers/amsr-e/AMSRE_Snow_Depth_Over_Ice.json
@@ -6,6 +6,9 @@
             "subtitle": "Aqua / AMSR-E",
             "group":    "overlays",
             "product": "AE_SI12",
+            "layergroup": [
+              "amsr-e"
+            ],
             "inactive": true,
 
             "palette": {

--- a/common/config/wv.json/layers/amsr-e/AMSRE_Surface_Precipitation_Rate_Day_v12_STD.json
+++ b/common/config/wv.json/layers/amsr-e/AMSRE_Surface_Precipitation_Rate_Day_v12_STD.json
@@ -7,6 +7,9 @@
             "tags":      "rain snow",
             "group":    "overlays",
             "product":  "AE_Rain",
+            "layergroup": [
+              "amsr-e"
+            ],
             "inactive": true
         }
     }

--- a/common/config/wv.json/layers/amsr-e/AMSRE_Surface_Precipitation_Rate_Night_v12_STD.json
+++ b/common/config/wv.json/layers/amsr-e/AMSRE_Surface_Precipitation_Rate_Night_v12_STD.json
@@ -7,6 +7,9 @@
             "tags":      "rain snow",
             "group":    "overlays",
             "product":  "AE_Rain",
+            "layergroup": [
+              "amsr-e"
+            ],
             "inactive": true
         }
     }

--- a/common/config/wv.json/layers/amsr-e/AMSRE_Surface_Rain_Rate_Day_v12_STD.json
+++ b/common/config/wv.json/layers/amsr-e/AMSRE_Surface_Rain_Rate_Day_v12_STD.json
@@ -6,6 +6,9 @@
             "subtitle": "Aqua / AMSR-E",
             "group":    "overlays",
             "product":  "AE_Rain",
+            "layergroup": [
+              "amsr-e"
+            ],
             "inactive": true
         }
     }

--- a/common/config/wv.json/layers/amsr-e/AMSRE_Surface_Rain_Rate_Night_v12_STD.json
+++ b/common/config/wv.json/layers/amsr-e/AMSRE_Surface_Rain_Rate_Night_v12_STD.json
@@ -6,6 +6,9 @@
             "subtitle": "Aqua / AMSR-E",
             "group":    "overlays",
             "product":  "AE_Rain",
+            "layergroup": [
+              "amsr-e"
+            ],
             "inactive": true
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Cloud_Liquid_Water_Day.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Cloud_Liquid_Water_Day.json
@@ -5,6 +5,9 @@
             "title":    "Columnar Cloud Liquid Water (Day)",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "A2_RainOcn_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Cloud_Liquid_Water_Night.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Cloud_Liquid_Water_Night.json
@@ -5,6 +5,9 @@
             "title":    "Columnar Cloud Liquid Water (Night)",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "A2_RainOcn_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Columnar_Water_Vapor_Day.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Columnar_Water_Vapor_Day.json
@@ -5,6 +5,9 @@
             "title":    "Columnar Water Vapor (Day)",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "A2_RainOcn_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Columnar_Water_Vapor_Night.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Columnar_Water_Vapor_Night.json
@@ -5,6 +5,9 @@
             "title":    "Columnar Water Vapor (Night)",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "A2_RainOcn_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Sea_Ice_Brightness_Temp_6km_89H.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Sea_Ice_Brightness_Temp_6km_89H.json
@@ -5,6 +5,9 @@
             "title":    "Sea Ice Brightness Temperature 6km 89H",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "A2_SI6_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Sea_Ice_Brightness_Temp_6km_89V.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Sea_Ice_Brightness_Temp_6km_89V.json
@@ -5,6 +5,9 @@
             "title":    "Sea Ice Brightness Temperature 6km 89V",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "A2_SI6_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Sea_Ice_Concentration_12km.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Sea_Ice_Concentration_12km.json
@@ -5,6 +5,9 @@
             "title":    "Sea Ice Concentration 12km",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "A2_SI12_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Sea_Ice_Concentration_25km.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Sea_Ice_Concentration_25km.json
@@ -5,6 +5,9 @@
             "title":    "Sea Ice Concentration 25km",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "A2_SI25_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Snow_Water_Equivalent.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Snow_Water_Equivalent.json
@@ -5,6 +5,9 @@
             "title":    "Snow Water Equivalent",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product": "A2_DySno_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Surface_Precipitation_Rate_Day.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Surface_Precipitation_Rate_Day.json
@@ -5,6 +5,9 @@
             "title":    "Surface Precipitation Rate (Day)",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "A2_RainOcn_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Surface_Precipitation_Rate_Night.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Surface_Precipitation_Rate_Night.json
@@ -5,6 +5,9 @@
             "title":    "Surface Precipitation Rate (Night)",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "A2_RainOcn_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Surface_Rain_Rate_Day.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Surface_Rain_Rate_Day.json
@@ -5,6 +5,9 @@
             "title":    "Surface Rain Rate (Day)",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "A2_RainOcn_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Surface_Rain_Rate_Night.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Surface_Rain_Rate_Night.json
@@ -5,6 +5,9 @@
             "title":    "Surface Rain Rate (Night)",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "A2_RainOcn_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Wind_Speed_Day.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Wind_Speed_Day.json
@@ -5,6 +5,9 @@
             "title":    "Wind Speed (Day)",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "A2_RainOcn_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSR2_Wind_Speed_Night.json
+++ b/common/config/wv.json/layers/amsr2/AMSR2_Wind_Speed_Night.json
@@ -5,6 +5,9 @@
             "title":    "Wind Speed (Night)",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "A2_RainOcn_NRT"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSRU2_Soil_Moisture_NPD_Day.json
+++ b/common/config/wv.json/layers/amsr2/AMSRU2_Soil_Moisture_NPD_Day.json
@@ -5,6 +5,9 @@
             "title":    "Soil Moisture (Normalized Polarization Difference, Day)",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "AU_Land"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSRU2_Soil_Moisture_NPD_Night.json
+++ b/common/config/wv.json/layers/amsr2/AMSRU2_Soil_Moisture_NPD_Night.json
@@ -5,6 +5,9 @@
             "title":    "Soil Moisture (Normalized Polarization Difference, Night)",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "AU_Land"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSRU2_Soil_Moisture_SCA_Day.json
+++ b/common/config/wv.json/layers/amsr2/AMSRU2_Soil_Moisture_SCA_Day.json
@@ -5,6 +5,9 @@
             "title":    "Soil Moisture (Single Channel Algorithm, Day)",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "AU_Land"
         }
     }

--- a/common/config/wv.json/layers/amsr2/AMSRU2_Soil_Moisture_SCA_Night.json
+++ b/common/config/wv.json/layers/amsr2/AMSRU2_Soil_Moisture_SCA_Night.json
@@ -5,6 +5,9 @@
             "title":    "Soil Moisture (Single Channel Algorithm, Night)",
             "subtitle": "GCOM-W1 / AMSR2",
             "group":    "overlays",
+            "layergroup": [
+              "amsr2"
+            ],
             "product":  "AU_Land"
         }
     }

--- a/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_3Month.json
+++ b/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_3Month.json
@@ -6,6 +6,9 @@
             "subtitle": "SAC-D/Aquarius",
             "tags":     "sss",
             "group":    "overlays",
+            "layergroup": [
+              "aquarius"
+            ],
             "product":  "AQUARIUS_L3_SSS_SMI_SEASONAL-CLIMATOLOGY_V4",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_7Day_RunningMean.json
+++ b/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_7Day_RunningMean.json
@@ -6,6 +6,9 @@
             "subtitle": "SAC-D/Aquarius",
             "tags":     "sss",
             "group":    "overlays",
+            "layergroup": [
+              "aquarius"
+            ],
             "product":  "AQUARIUS_L3_SSS_SMI_7DAY-RUNNINGMEAN_V4",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_7Day_Snapshot.json
+++ b/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_7Day_Snapshot.json
@@ -6,6 +6,9 @@
             "subtitle": "SAC-D/Aquarius",
             "tags":     "sss",
             "group":    "overlays",
+            "layergroup": [
+              "aquarius"
+            ],
             "product":  "AQUARIUS_L3_SSS_SMI_7DAY_V4",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_Daily.json
+++ b/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_Daily.json
@@ -6,6 +6,9 @@
             "subtitle": "SAC-D/Aquarius",
             "tags":     "sss",
             "group":    "overlays",
+            "layergroup": [
+              "aquarius"
+            ],
             "product":  "AQUARIUS_L3_SSS_SMI_DAILY_V4",
             "inactive": true
         }

--- a/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_Monthly.json
+++ b/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "SAC-D/Aquarius",
             "tags":     "sss",
             "group":    "overlays",
+            "layergroup": [
+              "aquarius"
+            ],
             "product":  "AQUARIUS_L3_SSS_SMI_MONTHLY-CLIMATOLOGY_V4",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/aquarius/Aquarius_Soil_Moisture_Daily.json
+++ b/common/config/wv.json/layers/aquarius/Aquarius_Soil_Moisture_Daily.json
@@ -6,6 +6,9 @@
             "subtitle": "SAC-D/Aquarius",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "aquarius"
+            ],
             "product":  "AQ3_DYSM",
             "inactive": true
         }

--- a/common/config/wv.json/layers/aquarius/Aquarius_Soil_Moisture_Weekly.json
+++ b/common/config/wv.json/layers/aquarius/Aquarius_Soil_Moisture_Weekly.json
@@ -6,6 +6,9 @@
             "subtitle": "SAC-D/Aquarius",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "aquarius"
+            ],
             "product":  "AQ3_WKSM",
             "startDate":"2011-08-25",
             "endDate":  "2015-06-10",

--- a/common/config/wv.json/layers/aquarius/Aquarius_Wind_Speed_L3_7Day_Snapshot.json
+++ b/common/config/wv.json/layers/aquarius/Aquarius_Wind_Speed_L3_7Day_Snapshot.json
@@ -6,6 +6,9 @@
             "subtitle": "SAC-D/Aquarius",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "aquarius"
+            ],
             "product":  "AQUARIUS_L3_WIND_SPEED_SMI_7DAY_V4",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/aquarius/Aquarius_Wind_Speed_L3_Daily.json
+++ b/common/config/wv.json/layers/aquarius/Aquarius_Wind_Speed_L3_Daily.json
@@ -6,6 +6,9 @@
             "subtitle": "SAC-D/Aquarius",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "aquarius"
+            ],
             "product":  "AQUARIUS_L3_WIND_SPEED_SMI_DAILY_V4",
             "inactive": true
         }

--- a/common/config/wv.json/layers/aster/ASTER_GDEM_Color_Index.json
+++ b/common/config/wv.json/layers/aster/ASTER_GDEM_Color_Index.json
@@ -7,6 +7,9 @@
             "tags":     "gdem",
             "group":    "overlays",
             "type":     "wmts",
+            "layergroup": [
+              "aster"
+            ],
             "product":  "ASTGTM",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/aster/ASTER_GDEM_Color_Shaded_Relief.json
+++ b/common/config/wv.json/layers/aster/ASTER_GDEM_Color_Shaded_Relief.json
@@ -7,6 +7,9 @@
             "tags":     "gdem",
             "group":    "baselayers",
             "type":     "wmts",
+            "layergroup": [
+              "aster"
+            ],
             "product":  "ASTGTM"
         }
     }

--- a/common/config/wv.json/layers/aster/ASTER_GDEM_Greyscale_Shaded_Relief.json
+++ b/common/config/wv.json/layers/aster/ASTER_GDEM_Greyscale_Shaded_Relief.json
@@ -7,6 +7,9 @@
             "tags":     "gdem",
             "group":    "baselayers",
             "type":     "wmts",
+            "layergroup": [
+              "aster"
+            ],
             "product":  "ASTGTM"
         }
     }

--- a/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Longwave_Flux_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Longwave_Flux_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra and Aqua/ CERES",
             "tags":     "top of atmosphere, cloud radiative effect",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2016-02-29",

--- a/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Longwave_Flux_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Longwave_Flux_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra and Aqua/ CERES",
             "tags":     "top of atmosphere, cloud radiative effect",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2016-02-29",

--- a/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Shortwave_Flux_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Shortwave_Flux_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra and Aqua/ CERES",
             "tags":     "top of atmosphere, cloud radiative effect",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2016-02-29",

--- a/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Shortwave_Flux_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Shortwave_Flux_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra and Aqua/ CERES",
             "tags":     "top of atmosphere, cloud radiative effect",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2016-02-29",

--- a/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Window_Region_Flux_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Window_Region_Flux_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra and Aqua/ CERES",
             "tags":     "top of atmosphere, cloud radiative effect",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2016-02-29",

--- a/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Window_Region_Flux_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Window_Region_Flux_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra and Aqua/ CERES",
             "tags":     "top of atmosphere, cloud radiative effect",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2016-02-29",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_CRE_Net_Longwave_Flux_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_CRE_Net_Longwave_Flux_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "cloud radiative effect",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_CRE_Net_Shortwave_Flux_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_CRE_Net_Shortwave_Flux_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "cloud radiative effect",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_CRE_Net_Total_Flux_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_CRE_Net_Total_Flux_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "cloud radiative effect",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Down_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Down_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Down_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Down_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Up_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Up_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Up_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Up_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Longwave_Flux_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Longwave_Flux_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Longwave_Flux_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Longwave_Flux_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Shortwave_Flux_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Shortwave_Flux_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Shortwave_Flux_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Shortwave_Flux_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Total_Flux_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Total_Flux_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Total_Flux_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Total_Flux_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Down_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Down_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Down_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Down_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Up_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Up_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Up_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Up_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_CRE_Longwave_Flux_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_CRE_Longwave_Flux_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere, cloud radiative effect",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_CRE_Net_Flux_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_CRE_Net_Flux_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere, cloud radiative effect",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_CRE_Shortwave_Flux_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_CRE_Shortwave_Flux_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere, cloud radiative effect",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Incoming_Solar_Flux_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Incoming_Solar_Flux_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Longwave_Flux_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Longwave_Flux_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Longwave_Flux_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Longwave_Flux_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Net_Flux_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Net_Flux_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Net_Flux_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Net_Flux_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Shortwave_Flux_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Shortwave_Flux_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Shortwave_Flux_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Shortwave_Flux_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Longwave_Flux_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Longwave_Flux_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2012-06-30",

--- a/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Longwave_Flux_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Longwave_Flux_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2012-06-30",

--- a/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Shortwave_Flux_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Shortwave_Flux_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2012-06-30",

--- a/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Shortwave_Flux_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Shortwave_Flux_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2012-06-30",

--- a/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Window_Region_Flux_All_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Window_Region_Flux_All_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2012-06-30",

--- a/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Window_Region_Flux_Clear_Sky_Monthly.json
+++ b/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Window_Region_Flux_Clear_Sky_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / CERES",
             "tags":     "top of atmosphere",
             "group":    "overlays",
+            "layergroup": [
+              "ceres"
+            ],
             "product":  "",
             "startDate":"2000-03-01",
             "endDate":  "2012-06-30",

--- a/common/config/wv.json/layers/daymet/Daymet_Maximum_Air_Temp_Daily.json
+++ b/common/config/wv.json/layers/daymet/Daymet_Maximum_Air_Temp_Daily.json
@@ -5,6 +5,9 @@
             "title":    "Maximum Air Temperature (Daily)",
             "subtitle": "Daymet",
             "group":    "overlays",
+            "layergroup": [
+              "daymet"
+            ],
             "product":  "1328",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/daymet/Daymet_Minimum_Air_Temp_Daily.json
+++ b/common/config/wv.json/layers/daymet/Daymet_Minimum_Air_Temp_Daily.json
@@ -5,6 +5,9 @@
             "title":    "Minimum Air Temperature (Daily)",
             "subtitle": "Daymet",
             "group":    "overlays",
+            "layergroup": [
+              "daymet"
+            ],
             "product":  "1328",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/gpm/GMI_Brightness_Temp_Asc.json
+++ b/common/config/wv.json/layers/gpm/GMI_Brightness_Temp_Asc.json
@@ -5,6 +5,9 @@
             "title":    "Brightness Temperature (Ascending)",
             "subtitle": "GPM / GMI",
             "group":    "overlays",
+            "layergroup": [
+              "gpm"
+            ],
             "product":  "GPM_1CGPMGMI"
         }
     }

--- a/common/config/wv.json/layers/gpm/GMI_Brightness_Temp_Dsc.json
+++ b/common/config/wv.json/layers/gpm/GMI_Brightness_Temp_Dsc.json
@@ -5,6 +5,9 @@
             "title":    "Brightness Temperature (Descending)",
             "subtitle": "GPM / GMI",
             "group":    "overlays",
+            "layergroup": [
+              "gpm"
+            ],
             "product":  "GPM_1CGPMGMI"
         }
     }

--- a/common/config/wv.json/layers/gpm/GMI_Rain_Rate_Asc.json
+++ b/common/config/wv.json/layers/gpm/GMI_Rain_Rate_Asc.json
@@ -5,6 +5,9 @@
             "title":    "Rain Rate (Ascending)",
             "subtitle": "GPM / GMI",
             "group":    "overlays",
+            "layergroup": [
+              "gpm"
+            ],
             "product":  "GPM_2AGPROFGPMGMI"
         }
     }

--- a/common/config/wv.json/layers/gpm/GMI_Rain_Rate_Dsc.json
+++ b/common/config/wv.json/layers/gpm/GMI_Rain_Rate_Dsc.json
@@ -5,6 +5,9 @@
             "title":    "Rain Rate (Descending)",
             "subtitle": "GPM / GMI",
             "group":    "overlays",
+            "layergroup": [
+              "gpm"
+            ],
             "product":  "GPM_2AGPROFGPMGMI"
         }
     }

--- a/common/config/wv.json/layers/gpm/GMI_Snow_Rate_Asc.json
+++ b/common/config/wv.json/layers/gpm/GMI_Snow_Rate_Asc.json
@@ -5,6 +5,9 @@
             "title":    "Snow Rate (Ascending)",
             "subtitle": "GPM / GMI",
             "group":    "overlays",
+            "layergroup": [
+              "gpm"
+            ],
             "product":  "GPM_2AGPROFGPMGMI"
         }
     }

--- a/common/config/wv.json/layers/gpm/GMI_Snow_Rate_Dsc.json
+++ b/common/config/wv.json/layers/gpm/GMI_Snow_Rate_Dsc.json
@@ -5,6 +5,9 @@
             "title":    "Snow Rate (Descending)",
             "subtitle": "GPM / GMI",
             "group":    "overlays",
+            "layergroup": [
+              "gpm"
+            ],
             "product":  "GPM_2AGPROFGPMGMI"
         }
     }

--- a/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_Alaska_Annual.json
+++ b/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_Alaska_Annual.json
@@ -6,6 +6,9 @@
             "subtitle": "Landsat / WELD",
             "tags":     "corrected, top of atmosphere",
             "group":    "baselayers",
+            "layergroup": [
+              "landsat"
+            ],
             "product":  "WELDAKYR",
             "startDate":"2002-12-01",
             "endDate":  "2012-11-30",

--- a/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_Alaska_Monthly.json
+++ b/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_Alaska_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Landsat / WELD",
             "tags":     "corrected, top of atmosphere",
             "group":    "baselayers",
+            "layergroup": [
+              "landsat"
+            ],
             "product":  "WELDAKMO",
             "startDate":"2002-12-01",
             "endDate":  "2012-11-30",

--- a/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_Alaska_Seasonal.json
+++ b/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_Alaska_Seasonal.json
@@ -6,6 +6,9 @@
             "subtitle": "Landsat / WELD",
             "tags":     "corrected, top of atmosphere",
             "group":    "baselayers",
+            "layergroup": [
+              "landsat"
+            ],
             "product":  "WELDAKSE",
             "startDate":"2002-12-01",
             "endDate":  "2012-11-30",

--- a/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_CONUS_Annual.json
+++ b/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_CONUS_Annual.json
@@ -6,6 +6,9 @@
             "subtitle": "Landsat / WELD",
             "tags":     "corrected, top of atmosphere",
             "group":    "baselayers",
+            "layergroup": [
+              "landsat"
+            ],
             "product":  "WELDUSYR",
             "startDate":"2002-12-01",
             "endDate":  "2012-11-30",

--- a/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_CONUS_Monthly.json
+++ b/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_CONUS_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Landsat / WELD",
             "tags":     "corrected, top of atmosphere",
             "group":    "baselayers",
+            "layergroup": [
+              "landsat"
+            ],
             "product":  "WELDUSMO",
             "startDate":"2002-12-01",
             "endDate":  "2012-11-30",

--- a/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_CONUS_Seasonal.json
+++ b/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_CONUS_Seasonal.json
@@ -6,6 +6,9 @@
             "subtitle": "Landsat / WELD",
             "tags":     "corrected, top of atmosphere",
             "group":    "baselayers",
+            "layergroup": [
+              "landsat"
+            ],
             "product":  "WELDUSSE",
             "startDate":"2002-12-01",
             "endDate":  "2012-11-30",

--- a/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_Global_Annual.json
+++ b/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_Global_Annual.json
@@ -6,6 +6,9 @@
             "subtitle": "Landsat / WELD",
             "tags":     "corrected, Nadir BRDF Adjusted Reflectance, Bi-directional Reflectance Distribution Function",
             "group":    "baselayers",
+            "layergroup": [
+              "landsat"
+            ],
             "product":  "",
             "startDate":"2008-12-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_Global_Monthly.json
+++ b/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_Global_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Landsat / WELD",
             "tags":     "corrected, Nadir BRDF Adjusted Reflectance, Bi-directional Reflectance Distribution Function",
             "group":    "baselayers",
+            "layergroup": [
+              "landsat"
+            ],
             "product":  "",
             "startDate":"2008-12-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/landsat/Landsat_WELD_NDVI_Global_Annual.json
+++ b/common/config/wv.json/layers/landsat/Landsat_WELD_NDVI_Global_Annual.json
@@ -6,6 +6,9 @@
             "subtitle": "Landsat / WELD",
             "tags":     "Nadir BRDF Adjusted Reflectance, Bi-directional Reflectance Distribution Function",
             "group":    "baselayers",
+            "layergroup": [
+              "landsat"
+            ],
             "product":  "",
             "startDate":"2008-12-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/landsat/Landsat_WELD_NDVI_Global_Monthly.json
+++ b/common/config/wv.json/layers/landsat/Landsat_WELD_NDVI_Global_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Landsat / WELD",
             "tags":     "Nadir BRDF Adjusted Reflectance, Bi-directional Reflectance Distribution Function",
             "group":    "baselayers",
+            "layergroup": [
+              "landsat"
+            ],
             "product":  "",
             "startDate":"2008-12-01",
             "endDate":  "2011-11-30",

--- a/common/config/wv.json/layers/ldas/GLDAS_Near_Surface_Air_Temperature_Monthly.json
+++ b/common/config/wv.json/layers/ldas/GLDAS_Near_Surface_Air_Temperature_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "GLDAS",
             "tags":     "global land data assimilation system, land surface model",
             "group":    "overlays",
+            "layergroup": [
+              "ldas"
+            ],
             "product":  "GLDAS_NOAH10_M.2.0",
             "startDate":"1948-01-01",
             "endDate":  "2010-12-31",

--- a/common/config/wv.json/layers/ldas/GLDAS_Surface_Total_Precipitation_Rate_Monthly.json
+++ b/common/config/wv.json/layers/ldas/GLDAS_Surface_Total_Precipitation_Rate_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "GLDAS",
             "tags":     "global land data assimilation system, land surface model",
             "group":    "overlays",
+            "layergroup": [
+              "ldas"
+            ],
             "product":  "GLDAS_NOAH10_M.2.0",
             "startDate":"1948-01-01",
             "endDate":  "2010-12-31",

--- a/common/config/wv.json/layers/ldas/GLDAS_Underground_Soil_Moisture_Monthly.json
+++ b/common/config/wv.json/layers/ldas/GLDAS_Underground_Soil_Moisture_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "GLDAS",
             "tags":     "global land data assimilation system, land surface model",
             "group":    "overlays",
+            "layergroup": [
+              "ldas"
+            ],
             "product":  "GLDAS_NOAH10_M.2.0",
             "startDate":"1948-01-01",
             "endDate":  "2010-12-31",

--- a/common/config/wv.json/layers/ldas/NLDAS_Near_Surface_Air_Temperature_Primary_Monthly.json
+++ b/common/config/wv.json/layers/ldas/NLDAS_Near_Surface_Air_Temperature_Primary_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "NLDAS",
             "tags":     "north american land data assimilation system",
             "group":    "overlays",
+            "layergroup": [
+              "ldas"
+            ],
             "product":  "NLDAS_FORA0125_M"
         }
     }

--- a/common/config/wv.json/layers/ldas/NLDAS_Surface_Total_Precipitation_Primary_Monthly.json
+++ b/common/config/wv.json/layers/ldas/NLDAS_Surface_Total_Precipitation_Primary_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "NLDAS",
             "tags":     "north american land data assimilation system",
             "group":    "overlays",
+            "layergroup": [
+              "ldas"
+            ],
             "product":  "NLDAS_FORA0125_M"
         }
     }

--- a/common/config/wv.json/layers/ldas/NLDAS_Surface_Total_Precipitation_Secondary_Monthly.json
+++ b/common/config/wv.json/layers/ldas/NLDAS_Surface_Total_Precipitation_Secondary_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "NLDAS",
             "tags":     "north american land data assimilation system",
             "group":    "overlays",
+            "layergroup": [
+              "ldas"
+            ],
             "product":  "NLDAS_FORB0125_M"
         }
     }

--- a/common/config/wv.json/layers/ldas/NLDAS_Underground_Soil_Moisture_Mosaic_Monthly.json
+++ b/common/config/wv.json/layers/ldas/NLDAS_Underground_Soil_Moisture_Mosaic_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "NLDAS",
             "tags":     "north american land data assimilation system",
             "group":    "overlays",
+            "layergroup": [
+              "ldas"
+            ],
             "product":  "NLDAS_MOS0125_M"
         }
     }

--- a/common/config/wv.json/layers/ldas/NLDAS_Underground_Soil_Moisture_Noah_Monthly.json
+++ b/common/config/wv.json/layers/ldas/NLDAS_Underground_Soil_Moisture_Noah_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "NLDAS",
             "tags":     "north american land data assimilation system",
             "group":    "overlays",
+            "layergroup": [
+              "ldas"
+            ],
             "product":  "NLDAS_NOAH0125_M"
         }
     }

--- a/common/config/wv.json/layers/ldas/NLDAS_Underground_Soil_Moisture_VIC_Monthly.json
+++ b/common/config/wv.json/layers/ldas/NLDAS_Underground_Soil_Moisture_VIC_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "NLDAS",
             "tags":     "north american land data assimilation system",
             "group":    "overlays",
+            "layergroup": [
+              "ldas"
+            ],
             "product":  "NLDAS_VIC0125_M"
         }
     }

--- a/common/config/wv.json/layers/measures/MEaSUREs_Daily_Landscape_Freeze_Thaw_AMSRE.json
+++ b/common/config/wv.json/layers/measures/MEaSUREs_Daily_Landscape_Freeze_Thaw_AMSRE.json
@@ -5,6 +5,9 @@
             "title":    "Freeze/Thaw (Daily Landscape)",
             "subtitle": "Aqua / AMSR-E",
             "group":    "overlays",
+            "layergroup": [
+              "measures"
+            ],
             "product": "NSIDC-0477",
             "inactive": true,
 

--- a/common/config/wv.json/layers/measures/MEaSUREs_Daily_Landscape_Freeze_Thaw_SSMI.json
+++ b/common/config/wv.json/layers/measures/MEaSUREs_Daily_Landscape_Freeze_Thaw_SSMI.json
@@ -5,6 +5,9 @@
             "title":    "Freeze/Thaw (Daily Landscape)",
             "subtitle": "DMSP / SSMI",
             "group":    "overlays",
+            "layergroup": [
+              "measures"
+            ],
             "product": "NSIDC-0477",
             "inactive": true,
 

--- a/common/config/wv.json/layers/merra/MERRA2_Surface_Pressure_Monthly.json
+++ b/common/config/wv.json/layers/merra/MERRA2_Surface_Pressure_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "MERRA-2",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "merra"
+            ],
             "product":  "M2IMNPASM",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/merra/MERRA2_Surface_Skin_Temperature_Monthly.json
+++ b/common/config/wv.json/layers/merra/MERRA2_Surface_Skin_Temperature_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "MERRA-2",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "merra"
+            ],
             "product":  "M2TMNXSLV",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/misr/MISR_Aerosol_Optical_Depth_Avg_Green_Monthly.json
+++ b/common/config/wv.json/layers/misr/MISR_Aerosol_Optical_Depth_Avg_Green_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MISR",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "misr"
+            ],
             "product":  "MIL3MAE",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/misr/MISR_Cloud_Stereo_Height_Histogram_Bin_0.5km_Monthly.json
+++ b/common/config/wv.json/layers/misr/MISR_Cloud_Stereo_Height_Histogram_Bin_0.5km_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MISR",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "misr"
+            ],
             "product":  "MIL3MCLD",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/misr/MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-2.0km_Monthly.json
+++ b/common/config/wv.json/layers/misr/MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-2.0km_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MISR",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "misr"
+            ],
             "product":  "MIL3MCLD",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/misr/MISR_Directional_Hemispherical_Reflectance_Average_Natural_Color_Monthly.json
+++ b/common/config/wv.json/layers/misr/MISR_Directional_Hemispherical_Reflectance_Average_Natural_Color_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MISR",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "misr"
+            ],
             "product":  "MIL3MLS",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/misr/MISR_Land_NDVI_Average_Monthly.json
+++ b/common/config/wv.json/layers/misr/MISR_Land_NDVI_Average_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MISR",
             "tags":     "normalized difference vegetation index",
             "group":    "overlays",
+            "layergroup": [
+              "misr"
+            ],
             "product":  "MIL3MLS",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/misr/MISR_Radiance_Average_Infrared_Color_Monthly.json
+++ b/common/config/wv.json/layers/misr/MISR_Radiance_Average_Infrared_Color_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MISR",
             "tags":     "ir",
             "group":    "overlays",
+            "layergroup": [
+              "misr"
+            ],
             "product":  "MIL3MRD",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/misr/MISR_Radiance_Average_Natural_Color_Monthly.json
+++ b/common/config/wv.json/layers/misr/MISR_Radiance_Average_Natural_Color_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MISR",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "misr"
+            ],
             "product":  "MIL3MRD",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/misr/MISR_TOA_Albedo_Average_Red_Monthly.json
+++ b/common/config/wv.json/layers/misr/MISR_TOA_Albedo_Average_Red_Monthly.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MISR",
             "tags":     "top of atmosphere",
             "group":    "overlays",
+            "layergroup": [
+              "misr"
+            ],
             "product":  "MIL3MAL",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/mls/MLS_CO_215hPa_Day.json
+++ b/common/config/wv.json/layers/mls/MLS_CO_215hPa_Day.json
@@ -6,6 +6,9 @@
             "subtitle": "Aura / MLS",
             "tags":     "co",
             "group":    "overlays",
+            "layergroup": [
+              "mls"
+            ],
             "product":  "ML2CO"
         }
     }

--- a/common/config/wv.json/layers/mls/MLS_CO_215hPa_Night.json
+++ b/common/config/wv.json/layers/mls/MLS_CO_215hPa_Night.json
@@ -6,6 +6,9 @@
             "subtitle": "Aura / MLS",
             "tags":     "co",
             "group":    "overlays",
+            "layergroup": [
+              "mls"
+            ],
             "product":  "ML2CO"
         }
     }

--- a/common/config/wv.json/layers/mls/MLS_H2O_46hPa_Day.json
+++ b/common/config/wv.json/layers/mls/MLS_H2O_46hPa_Day.json
@@ -6,6 +6,9 @@
             "subtitle": "Aura / MLS",
             "tags":     "h2o",
             "group":    "overlays",
+            "layergroup": [
+              "mls"
+            ],
             "product":  "ML2H2O"
         }
     }

--- a/common/config/wv.json/layers/mls/MLS_H2O_46hPa_Night.json
+++ b/common/config/wv.json/layers/mls/MLS_H2O_46hPa_Night.json
@@ -6,6 +6,9 @@
             "subtitle": "Aura / MLS",
             "tags":     "h2o",
             "group":    "overlays",
+            "layergroup": [
+              "mls"
+            ],
             "product":  "ML2H2O"
         }
     }

--- a/common/config/wv.json/layers/mls/MLS_HNO3_46hPa_Day.json
+++ b/common/config/wv.json/layers/mls/MLS_HNO3_46hPa_Day.json
@@ -6,6 +6,9 @@
             "subtitle": "Aura / MLS",
             "tags":     "hno3",
             "group":    "overlays",
+            "layergroup": [
+              "mls"
+            ],
             "product":  "ML2HNO3"
         }
     }

--- a/common/config/wv.json/layers/mls/MLS_HNO3_46hPa_Night.json
+++ b/common/config/wv.json/layers/mls/MLS_HNO3_46hPa_Night.json
@@ -6,6 +6,9 @@
             "subtitle": "Aura / MLS",
             "tags":     "hno3",
             "group":    "overlays",
+            "layergroup": [
+              "mls"
+            ],
             "product":  "ML2HNO3"
         }
     }

--- a/common/config/wv.json/layers/mls/MLS_N2O_46hPa_Day.json
+++ b/common/config/wv.json/layers/mls/MLS_N2O_46hPa_Day.json
@@ -6,6 +6,9 @@
             "subtitle": "Aura / MLS",
             "tags":     "n2o",
             "group":    "overlays",
+            "layergroup": [
+              "mls"
+            ],
             "product":  "ML2N2O"
         }
     }

--- a/common/config/wv.json/layers/mls/MLS_N2O_46hPa_Night.json
+++ b/common/config/wv.json/layers/mls/MLS_N2O_46hPa_Night.json
@@ -6,6 +6,9 @@
             "subtitle": "Aura / MLS",
             "tags":     "n2o",
             "group":    "overlays",
+            "layergroup": [
+              "mls"
+            ],
             "product":  "ML2N2O"
         }
     }

--- a/common/config/wv.json/layers/mls/MLS_O3_46hPa_Day.json
+++ b/common/config/wv.json/layers/mls/MLS_O3_46hPa_Day.json
@@ -6,6 +6,9 @@
             "subtitle": "Aura / MLS",
             "tags":     "o3",
             "group":    "overlays",
+            "layergroup": [
+              "mls"
+            ],
             "product":  "ML2O3"
         }
     }

--- a/common/config/wv.json/layers/mls/MLS_O3_46hPa_Night.json
+++ b/common/config/wv.json/layers/mls/MLS_O3_46hPa_Night.json
@@ -6,6 +6,9 @@
             "subtitle": "Aura / MLS",
             "tags":     "o3",
             "group":    "overlays",
+            "layergroup": [
+              "mls"
+            ],
             "product":  "ML2O3"
         }
     }

--- a/common/config/wv.json/layers/mls/MLS_SO2_147hPa_Day.json
+++ b/common/config/wv.json/layers/mls/MLS_SO2_147hPa_Day.json
@@ -6,6 +6,9 @@
             "subtitle": "Aura / MLS",
             "tags":     "so2 sulphur",
             "group":    "overlays",
+            "layergroup": [
+              "mls"
+            ],
             "product":  "ML2SO2"
         }
     }

--- a/common/config/wv.json/layers/mls/MLS_SO2_147hPa_Night.json
+++ b/common/config/wv.json/layers/mls/MLS_SO2_147hPa_Night.json
@@ -6,6 +6,9 @@
             "subtitle": "Aura / MLS",
             "tags":     "so2 sulphur",
             "group":    "overlays",
+            "layergroup": [
+              "mls"
+            ],
             "product":  "ML2SO2"
         }
     }

--- a/common/config/wv.json/layers/mls/MLS_Temperature_46hPa_Day.json
+++ b/common/config/wv.json/layers/mls/MLS_Temperature_46hPa_Day.json
@@ -5,6 +5,9 @@
             "title":    "Temperature (46 hPa, Day)",
             "subtitle": "Aura / MLS",
             "group":    "overlays",
+            "layergroup": [
+              "mls"
+            ],
             "product":  "ML2T"
         }
     }

--- a/common/config/wv.json/layers/mls/MLS_Temperature_46hPa_Night.json
+++ b/common/config/wv.json/layers/mls/MLS_Temperature_46hPa_Night.json
@@ -5,6 +5,9 @@
             "title":    "Temperature (46 hPa, Night)",
             "subtitle": "Aura / MLS",
             "group":    "overlays",
+            "layergroup": [
+              "mls"
+            ],
             "product":  "ML2T"
         }
     }

--- a/common/config/wv.json/layers/modis/MODIS_Combined_Value_Added_AOD.json
+++ b/common/config/wv.json/layers/modis/MODIS_Combined_Value_Added_AOD.json
@@ -6,6 +6,10 @@
             "subtitle": "Terra and Aqua / MODIS",
             "tags":     "aod",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MCDAODHD",
             "wrapadjacentdays": true,
 

--- a/common/config/wv.json/layers/modis/MODIS_Fires_All.json
+++ b/common/config/wv.json/layers/modis/MODIS_Fires_All.json
@@ -10,7 +10,10 @@
             "period":   "daily",
             "tileSize": [512, 512],
             "type":     "wms",
-
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "transition":   "true",
             "startDate":    "2012-05-08",
 

--- a/common/config/wv.json/layers/modis/Sea_Surface_Temp_Infrared.json
+++ b/common/config/wv.json/layers/modis/Sea_Surface_Temp_Infrared.json
@@ -6,7 +6,10 @@
             "subtitle": "PODAAC / MODIS / Terra and Aqua / 5 day",
             "tags":     "sst",
             "group":    "overlays",
-
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "palette": {
                 "recommended":  ["purple_2"]
             }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_AOD_Deep_Blue_Combined.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_AOD_Deep_Blue_Combined.json
@@ -6,6 +6,10 @@
             "subtitle": "Aqua / MODIS",
             "tags":     "aod",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD04_L2",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_AOD_Deep_Blue_Land.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_AOD_Deep_Blue_Land.json
@@ -6,6 +6,10 @@
             "subtitle": "Aqua / MODIS",
             "tags":     "aod",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD04_L2",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Aerosol.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Aerosol.json
@@ -6,6 +6,10 @@
             "subtitle": "Aqua / MODIS",
             "tags":     "aod",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD04_L2",
             "wrapadjacentdays": true,
 

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Aerosol_Optical_Depth_3km.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Aerosol_Optical_Depth_3km.json
@@ -6,6 +6,10 @@
             "subtitle": "Aqua / MODIS",
             "tags":     "aod",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD04_3K",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Angstrom_Exponent_Land.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Angstrom_Exponent_Land.json
@@ -6,6 +6,10 @@
             "subtitle": "Aqua / MODIS",
             "tags":     "aod",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD04_L2",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Angstrom_Exponent_Ocean.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Angstrom_Exponent_Ocean.json
@@ -6,6 +6,10 @@
             "subtitle": "Aqua / MODIS",
             "tags":     "aod",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD04_L2",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Brightness_Temp_Band31_Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Brightness_Temp_Band31_Day.json
@@ -5,6 +5,10 @@
             "title":    "Brightness Temperature (Band 31-Day)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD021KM_DAY",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Brightness_Temp_Band31_Night.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Brightness_Temp_Band31_Night.json
@@ -5,6 +5,10 @@
             "title":    "Brightness Temperature (Band 31-Night)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD021KM_NIGHT"
         }
     }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Chlorophyll_A.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Chlorophyll_A.json
@@ -4,7 +4,11 @@
             "id":       "MODIS_Aqua_Chlorophyll_A",
             "title":    "Chlorophyll a",
             "subtitle": "Aqua / MODIS",
-            "group":    "overlays"
+            "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ]
         }
     }
 }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Effective_Radius.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Effective_Radius.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Effective Radius",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Effective_Radius_37.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Effective_Radius_37.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Effective Radius (3.7 micron)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Effective_Radius_37_PCL.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Effective_Radius_37_PCL.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Effective Radius (3.7 micron PCL)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Effective_Radius_PCL.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Effective_Radius_PCL.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Effective Radius (PCL)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Fraction_Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Fraction_Day.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Fraction (Day)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2_DAY",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Fraction_Night.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Fraction_Night.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Fraction (Night)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2_NIGHT"
         }
     }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Multi_Layer_Flag.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Multi_Layer_Flag.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Multi Layer Flag",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Optical_Thickness.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Optical_Thickness.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Optical Thickness",
             "subtitle": "Aqua/MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Optical_Thickness_PCL.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Optical_Thickness_PCL.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Optical Thickness (PCL)",
             "subtitle": "Aqua/MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Phase_Infrared_Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Phase_Infrared_Day.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Phase Infrared (Day)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2_DAY",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Phase_Infrared_Night.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Phase_Infrared_Night.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Phase Infrared (Night)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2_NIGHT"
         }
     }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Phase_Optical_Properties.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Phase_Optical_Properties.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Phase Optical Properties",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Top_Height_Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Top_Height_Day.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Top Height (Day)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2_DAY",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Top_Height_Night.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Top_Height_Night.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Top Height (Night)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2_NIGHT"
         }
     }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Top_Pressure_Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Top_Pressure_Day.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Top Pressure (Day)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2_DAY",
             "wrapadjacentdays": true,
 

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Top_Pressure_Night.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Top_Pressure_Night.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Top Pressure (Night)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2_NIGHT",
 
             "palette": {

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Top_Temp_Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Top_Temp_Day.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Top Temperature (Day)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2_DAY",
             "wrapadjacentdays": true,
 

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Top_Temp_Night.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Top_Temp_Night.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Top Temperature (Night)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2_NIGHT",
 
             "palette": {

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Water_Path.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Water_Path.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Water Path",
             "subtitle": "Aqua/MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Water_Path_PCL.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Cloud_Water_Path_PCL.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Water Path (PCL)",
             "subtitle": "Aqua/MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_CorrectedReflectance_Bands721.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_CorrectedReflectance_Bands721.json
@@ -6,6 +6,10 @@
             "subtitle": "Aqua / MODIS",
             "tags":     "cr m11-i2-i1",
             "group":    "baselayers",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "wrapadjacentdays": true
         }
     }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_CorrectedReflectance_TrueColor.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_CorrectedReflectance_TrueColor.json
@@ -6,6 +6,10 @@
             "subtitle": "Aqua / MODIS",
             "tags":     "natural color cr",
             "group":    "baselayers",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "wrapadjacentdays": true
         }
     }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Ice_Surface_Temp_Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Ice_Surface_Temp_Day.json
@@ -5,6 +5,10 @@
             "title":    "Ice Surface Temperature (Day)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD29",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Ice_Surface_Temp_Night.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Ice_Surface_Temp_Night.json
@@ -5,6 +5,10 @@
             "title":    "Ice Surface Temperature (Night)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD29"
         }
     }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_8Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_8Day.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, 8 Day, Mid Infrared, 4 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_MID-IR_8DAY_4KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_Annual.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_Annual.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Annual, Mid Infrared, 4 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_MID-IR_ANNUAL_4KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2014.0"
         }
     }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_Monthly.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Monthly, Mid Infrared, 4 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_MID-IR_MONTHLY_4KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_9km_Night_8Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_9km_Night_8Day.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, 8 Day, Mid Infrared, 9 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_MID-IR_8DAY_9KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_9km_Night_Annual.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_9km_Night_Annual.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Annual, Mid Infrared, 9 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_MID-IR_ANNUAL_9KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_9km_Night_Daily.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_9km_Night_Daily.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 9 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_MID-IR_DAILY_9KM_NIGHTTIME_V2014.0"
         }
     }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_9km_Night_Monthly.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_9km_Night_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Monthly, Mid Infrared, 9 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_MID-IR_MONTHLY_9KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Day_8Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Day_8Day.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, 8 Day, Thermal, 4 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_8DAY_4KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Day_Annual.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Day_Annual.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, Annual, Thermal, 4 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_ANNUAL_4KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Day_Daily.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Day_Daily.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, Daily, Thermal, 4 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_DAILY_4KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Day_Monthly.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Day_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, Monthly, Thermal, 4 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_MONTHLY_4KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Night_8Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Night_8Day.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, 8 Day, Thermal, 4 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_8DAY_4KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Night_Annual.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Night_Annual.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Annual, Thermal, 4 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_ANNUAL_4KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Night_Daily.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Night_Daily.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Daily, Thermal, 4 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_DAILY_4KM_NIGHTTIME_V2014.0"
         }
     }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Night_Monthly.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Night_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Monthly, Thermal, 4 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_MONTHLY_4KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Day_8Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Day_8Day.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, 8 Day, Thermal, 9 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_8DAY_9KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Day_Annual.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Day_Annual.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, Annual, Thermal, 9 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_ANNUAL_9KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Day_Daily.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Day_Daily.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, Daily, Thermal, 9 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_DAILY_9KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Day_Monthly.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Day_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, Monthly, Thermal, 9 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_MONTHLY_9KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Night_8Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Night_8Day.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, 8 Day, Thermal, 9 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_8DAY_9KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Night_Annual.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Night_Annual.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Annual, Thermal, 9 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_ANNUAL_9KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Night_Daily.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Night_Daily.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Daily, Thermal, 9 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_DAILY_9KM_NIGHTTIME_V2014.0"
         }
     }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Night_Monthly.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Night_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Monthly, Thermal, 9 km)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MODIS_AQUA_L3_SST_THERMAL_MONTHLY_9KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Land_Surface_Temp_Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Land_Surface_Temp_Day.json
@@ -6,6 +6,10 @@
             "subtitle": "Aqua / MODIS",
             "tags":     "lst",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD11_L2_DAY",
             "wrapadjacentdays": true,
 

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Land_Surface_Temp_Night.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Land_Surface_Temp_Night.json
@@ -6,6 +6,10 @@
             "subtitle": "Aqua / MODIS",
             "tags":     "lst",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD11_L2_NIGHT",
 
             "palette": {

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_NDSI_Snow_Cover.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_NDSI_Snow_Cover.json
@@ -5,6 +5,10 @@
             "title":    "Snow Cover (Normalized Snow Difference Index)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD10_L2",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Sea_Ice.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Sea_Ice.json
@@ -5,6 +5,10 @@
             "title":    "Sea Ice",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD29",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Snow_Cover.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Snow_Cover.json
@@ -5,6 +5,10 @@
             "title":    "Snow Cover",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD10_L2",
             "wrapadjacentdays": true,
 

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_SurfaceReflectance_Bands121.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_SurfaceReflectance_Bands121.json
@@ -6,6 +6,10 @@
             "subtitle": "Aqua / MODIS",
             "tags":     "lsr",
             "group":    "baselayers",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD09GQ",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_SurfaceReflectance_Bands143.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_SurfaceReflectance_Bands143.json
@@ -6,6 +6,10 @@
             "subtitle": "Aqua / MODIS",
             "tags":     "lsr",
             "group":    "baselayers",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD09GA",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_SurfaceReflectance_Bands721.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_SurfaceReflectance_Bands721.json
@@ -6,6 +6,10 @@
             "subtitle": "Aqua / MODIS",
             "tags":     "lsr m11-i2-i1",
             "group":    "baselayers",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD09GA",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Water_Vapor_5km_Day.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Water_Vapor_5km_Day.json
@@ -5,6 +5,10 @@
             "title":    "Water Vapor (Day)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD05_L2_DAY",
             "wrapadjacentdays": true,
 

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Water_Vapor_5km_Night.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Water_Vapor_5km_Night.json
@@ -5,6 +5,10 @@
             "title":    "Water Vapor (Night)",
             "subtitle": "Aqua / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD05_L2_NIGHT",
 
             "palette": {

--- a/common/config/wv.json/layers/modis/aqua/MODIS_Fires_Aqua.json
+++ b/common/config/wv.json/layers/modis/aqua/MODIS_Fires_Aqua.json
@@ -8,6 +8,10 @@
             "group":    "overlays",
             "format":   "image/png",
             "period":   "daily",
+            "layergroup": [
+              "modis",
+              "modis_aqua"
+            ],
             "product":  "MYD14",
 
             "tileSize": [512, 512],

--- a/common/config/wv.json/layers/modis/terra/MODIS_Fires_Terra.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Fires_Terra.json
@@ -8,6 +8,10 @@
             "group":    "overlays",
             "format":   "image/png",
             "period":   "daily",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD14",
 
             "tileSize": [512, 512],

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_AOD_Deep_Blue_Combined.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_AOD_Deep_Blue_Combined.json
@@ -6,6 +6,10 @@
             "subtitle": "Terra / MODIS",
             "tags":     "aod",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD04_L2",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_AOD_Deep_Blue_Land.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_AOD_Deep_Blue_Land.json
@@ -6,6 +6,10 @@
             "subtitle": "Terra / MODIS",
             "tags":     "aod",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD04_L2",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Aerosol.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Aerosol.json
@@ -6,6 +6,10 @@
             "subtitle": "Terra / MODIS",
             "tags":     "aod",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD04_L2",
             "wrapadjacentdays": true,
 

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Aerosol_Optical_Depth_3km.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Aerosol_Optical_Depth_3km.json
@@ -6,6 +6,10 @@
             "subtitle": "Terra / MODIS",
             "tags":     "aod",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD04_3K",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Angstrom_Exponent_Land.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Angstrom_Exponent_Land.json
@@ -6,6 +6,10 @@
             "subtitle": "Terra / MODIS",
             "tags":     "aod",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD04_L2",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Angstrom_Exponent_Ocean.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Angstrom_Exponent_Ocean.json
@@ -6,6 +6,10 @@
             "subtitle": "Terra / MODIS",
             "tags":     "aod",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD04_L2",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Brightness_Temp_Band31_Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Brightness_Temp_Band31_Day.json
@@ -5,6 +5,10 @@
             "title":    "Brightness Temperature (Band 31-Day)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD021KM_DAY",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Brightness_Temp_Band31_Night.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Brightness_Temp_Band31_Night.json
@@ -5,6 +5,10 @@
             "title":    "Brightness Temperature (Band 31-Night)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD021KM_NIGHT"
         }
     }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Effective_Radius.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Effective_Radius.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Effective Radius",
             "subtitle": "Terra/MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Effective_Radius_37.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Effective_Radius_37.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Effective Radius (3.7 micron)",
             "subtitle": "Terra/MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Effective_Radius_37_PCL.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Effective_Radius_37_PCL.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Effective Radius (3.7 micron PCL)",
             "subtitle": "Terra/MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Effective_Radius_PCL.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Effective_Radius_PCL.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Effective Radius (PCL)",
             "subtitle": "Terra/MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Fraction_Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Fraction_Day.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Fraction (Day)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2_DAY",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Fraction_Night.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Fraction_Night.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Fraction (Night)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2_NIGHT"
             }
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Multi_Layer_Flag.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Multi_Layer_Flag.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Multi Layer Flag",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Optical_Thickness.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Optical_Thickness.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Optical Thickness",
             "subtitle": "Terra/MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Optical_Thickness_PCL.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Optical_Thickness_PCL.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Optical Thickness (PCL)",
             "subtitle": "Terra/MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Phase_Infrared_Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Phase_Infrared_Day.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Phase Infrared (Day)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2_DAY",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Phase_Infrared_Night.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Phase_Infrared_Night.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Phase Infrared (Night)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2_NIGHT"
             }
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Phase_Optical_Properties.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Phase_Optical_Properties.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Phase Optical Properties",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Top_Height_Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Top_Height_Day.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Top Height (Day)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2_DAY",
             "wrapadjacentdays": true
             }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Top_Height_Night.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Top_Height_Night.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Top Height (Night)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2_NIGHT"
             }
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Top_Pressure_Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Top_Pressure_Day.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Top Pressure (Day)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2_DAY",
             "wrapadjacentdays": true,
 

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Top_Pressure_Night.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Top_Pressure_Night.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Top Pressure (Night)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2_NIGHT",
 
             "palette": {

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Top_Temp_Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Top_Temp_Day.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Top Temperature (Day)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2_DAY",
             "wrapadjacentdays": true,
 

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Top_Temp_Night.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Top_Temp_Night.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Top Temperature (Night)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2_NIGHT",
 
             "palette": {

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Water_Path.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Water_Path.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Water Path",
             "subtitle": "Terra/MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Water_Path_PCL.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Cloud_Water_Path_PCL.json
@@ -5,6 +5,10 @@
             "title":    "Cloud Water Path (PCL)",
             "subtitle": "Terra/MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD06_L2",
             "wrapadjacentdays": true
 

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_EVI_8Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_EVI_8Day.json
@@ -5,6 +5,10 @@
             "title":    "Enhanced Vegetation Index (EVI) (rolling 8-day)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD13Q4N",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Ice_Surface_Temp_Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Ice_Surface_Temp_Day.json
@@ -5,6 +5,10 @@
             "title":    "Ice Surface Temperature (Day)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD29",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Ice_Surface_Temp_Night.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Ice_Surface_Temp_Night.json
@@ -5,6 +5,10 @@
             "title":    "Ice Surface Temperature (Night)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD29"
         }
     }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_4km_Night_8Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_4km_Night_8Day.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, 8 Day, Mid Infrared, 4 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_MID-IR_8DAY_4KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_4km_Night_Annual.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_4km_Night_Annual.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Annual, Mid Infrared, 4 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_MID-IR_ANNUAL_4KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_4km_Night_Daily.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_4km_Night_Daily.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2014.0"
         }
     }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_4km_Night_Monthly.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_4km_Night_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Monthly, Mid Infrared, 4 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_MID-IR_MONTHLY_4KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_9km_Night_8Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_9km_Night_8Day.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, 8 Day, Mid Infrared, 9 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_MID-IR_8DAY_9KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_9km_Night_Annual.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_9km_Night_Annual.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Annual, Mid Infrared, 9 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_MID-IR_ANNUAL_9KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_9km_Night_Daily.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_9km_Night_Daily.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 9 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_MID-IR_DAILY_9KM_NIGHTTIME_V2014.0"
         }
     }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_9km_Night_Monthly.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_9km_Night_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Monthly, Mid Infrared, 9 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_MID-IR_MONTHLY_9KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Day_8Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Day_8Day.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, 8 Day, Thermal, 4 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_8DAY_4KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Day_Annual.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Day_Annual.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, Annual, Thermal, 4 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_ANNUAL_4KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Day_Daily.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Day_Daily.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, Daily, Thermal, 4 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_DAILY_4KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Day_Monthly.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Day_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, Monthly, Thermal, 4 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_MONTHLY_4KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Night_8Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Night_8Day.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, 8 Day, Thermal, 4 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_8DAY_4KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Night_Annual.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Night_Annual.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Annual, Thermal, 4 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_ANNUAL_4KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Night_Daily.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Night_Daily.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Daily, Thermal, 4 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_DAILY_4KM_NIGHTTIME_V2014.0"
         }
     }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Night_Monthly.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Night_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Monthly, Thermal, 4 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_MONTHLY_4KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Day_8Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Day_8Day.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, 8 Day, Thermal, 9 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_8DAY_9KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Day_Annual.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Day_Annual.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, Annual, Thermal, 9 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_ANNUAL_9KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Day_Daily.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Day_Daily.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, Daily, Thermal, 9 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_DAILY_9KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Day_Monthly.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Day_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Day, Monthly, Thermal, 9 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_MONTHLY_9KM_DAYTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_8Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_8Day.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, 8 Day, Thermal, 9 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_8DAY_9KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_Annual.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_Annual.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Annual, Thermal, 9 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_ANNUAL_9KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_Daily.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_Daily.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Daily, Thermal, 9 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_DAILY_9KM_NIGHTTIME_V2014.0"
         }
     }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_Monthly.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L3, Night, Monthly,  Thermal, 9 km)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MODIS_TERRA_L3_SST_THERMAL_MONTHLY_9KM_NIGHTTIME_V2014.0",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Land_Surface_Temp_Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Land_Surface_Temp_Day.json
@@ -6,6 +6,10 @@
             "subtitle": "Terra / MODIS",
             "tags":     "lst",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD11_L2_DAY",
             "wrapadjacentdays": true,
 

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Land_Surface_Temp_Night.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Land_Surface_Temp_Night.json
@@ -6,6 +6,10 @@
             "subtitle": "Terra / MODIS",
             "tags":     "lst",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD11_L2_NIGHT",
 
             "palette": {

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_NDSI_Snow_Cover.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_NDSI_Snow_Cover.json
@@ -5,6 +5,10 @@
             "title":    "Snow Cover (Normalized Difference Snow Index)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD10_L2",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_NDVI_8Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_NDVI_8Day.json
@@ -5,6 +5,10 @@
             "title":    "Normalized Difference Vegetation Index (NDVI) (rolling 8-day)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD13Q4N",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Sea_Ice.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Sea_Ice.json
@@ -5,6 +5,10 @@
             "title":    "Sea Ice",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD29",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Snow_Cover.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Snow_Cover.json
@@ -5,6 +5,10 @@
             "title":    "Snow Cover",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD10_L2",
             "wrapadjacentdays": true,
 

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_SurfaceReflectance_Bands121.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_SurfaceReflectance_Bands121.json
@@ -6,6 +6,10 @@
             "subtitle": "Terra / MODIS",
             "tags":     "lsr",
             "group":    "baselayers",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD09GQ",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_SurfaceReflectance_Bands143.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_SurfaceReflectance_Bands143.json
@@ -6,6 +6,10 @@
             "subtitle": "Terra / MODIS",
             "tags":     "lsr",
             "group":    "baselayers",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD09GA",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_SurfaceReflectance_Bands721.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_SurfaceReflectance_Bands721.json
@@ -6,6 +6,10 @@
             "subtitle": "Terra / MODIS",
             "tags":     "lsr m11-i2-i1",
             "group":    "baselayers",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD09GA",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Water_Vapor_5km_Day.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Water_Vapor_5km_Day.json
@@ -5,6 +5,10 @@
             "title":    "Water Vapor (Day)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD05_L2_DAY",
             "wrapadjacentdays": true,
 

--- a/common/config/wv.json/layers/modis/terra/MODIS_Terra_Water_Vapor_5km_Night.json
+++ b/common/config/wv.json/layers/modis/terra/MODIS_Terra_Water_Vapor_5km_Night.json
@@ -5,6 +5,10 @@
             "title":    "Water Vapor (Night)",
             "subtitle": "Terra / MODIS",
             "group":    "overlays",
+            "layergroup": [
+              "modis",
+              "modis_terra"
+            ],
             "product":  "MOD05_L2_NIGHT",
 
             "palette": {

--- a/common/config/wv.json/layers/mopitt/MOPITT_CO_Daily_Surface_Mixing_Ratio_Day.json
+++ b/common/config/wv.json/layers/mopitt/MOPITT_CO_Daily_Surface_Mixing_Ratio_Day.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MOPITT",
             "tags":     "co",
             "group":    "overlays",
+            "layergroup": [
+              "mopitt"
+            ],
             "product":  "MOP03J"
         }
     }

--- a/common/config/wv.json/layers/mopitt/MOPITT_CO_Daily_Surface_Mixing_Ratio_Night.json
+++ b/common/config/wv.json/layers/mopitt/MOPITT_CO_Daily_Surface_Mixing_Ratio_Night.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MOPITT",
             "tags":     "co",
             "group":    "overlays",
+            "layergroup": [
+              "mopitt"
+            ],
             "product":  "MOP03J"
         }
     }

--- a/common/config/wv.json/layers/mopitt/MOPITT_CO_Daily_Total_Column_Day.json
+++ b/common/config/wv.json/layers/mopitt/MOPITT_CO_Daily_Total_Column_Day.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MOPITT",
             "tags":     "co",
             "group":    "overlays",
+            "layergroup": [
+              "mopitt"
+            ],
             "product":  "MOP03J"
         }
     }

--- a/common/config/wv.json/layers/mopitt/MOPITT_CO_Daily_Total_Column_Night.json
+++ b/common/config/wv.json/layers/mopitt/MOPITT_CO_Daily_Total_Column_Night.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MOPITT",
             "tags":     "co",
             "group":    "overlays",
+            "layergroup": [
+              "mopitt"
+            ],
             "product":  "MOP03J"
         }
     }

--- a/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Surface_Mixing_Ratio_Day.json
+++ b/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Surface_Mixing_Ratio_Day.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MOPITT",
             "tags":     "co",
             "group":    "overlays",
+            "layergroup": [
+              "mopitt"
+            ],
             "product":  "MOP03JM",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Surface_Mixing_Ratio_Night.json
+++ b/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Surface_Mixing_Ratio_Night.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MOPITT",
             "tags":     "co",
             "group":    "overlays",
+            "layergroup": [
+              "mopitt"
+            ],
             "product":  "MOP03JM",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Total_Column_Day.json
+++ b/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Total_Column_Day.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MOPITT",
             "tags":     "co",
             "group":    "overlays",
+            "layergroup": [
+              "mopitt"
+            ],
             "product":  "MOP03JM",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Total_Column_Night.json
+++ b/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Total_Column_Night.json
@@ -6,6 +6,9 @@
             "subtitle": "Terra / MOPITT",
             "tags":     "co",
             "group":    "overlays",
+            "layergroup": [
+              "mopitt"
+            ],
             "product":  "MOP03JM",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/multi-mission/ghrsst/GHRSST_L4_G1SST_Sea_Surface_Temperature.json
+++ b/common/config/wv.json/layers/multi-mission/ghrsst/GHRSST_L4_G1SST_Sea_Surface_Temperature.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L4, G1SST)",
             "subtitle": "Multi-mission / GHRSST",
             "tags":     "sst ghrsst",
+            "layergroup": [
+              "multi-mission",
+              "multi-mission_ghrsst"
+            ],
             "product": 	"GHRSST_L4G1SST_LL",
             "group":    "overlays",
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/multi-mission/ghrsst/GHRSST_L4_MUR_Sea_Surface_Temperature.json
+++ b/common/config/wv.json/layers/multi-mission/ghrsst/GHRSST_L4_MUR_Sea_Surface_Temperature.json
@@ -5,6 +5,10 @@
             "title":    "Sea Surface Temperature (L4, MUR)",
             "subtitle": "Multi-mission / GHRSST",
             "tags":     "sst ghrsst",
+            "layergroup": [
+              "multi-mission",
+              "multi-mission_ghrsst"
+            ],
             "product": 	"GHRSST_L4MUR_LL",
             "group":    "overlays",
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/multi-mission/merged/CCMP_REMSS_Meridional_Wind_Speed_Monthly.json
+++ b/common/config/wv.json/layers/multi-mission/merged/CCMP_REMSS_Meridional_Wind_Speed_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Wind Speed (Meridional, REMSS, Monthly)",
             "subtitle": "CCMP",
             "tags":     "",
+            "layergroup": [
+              "multi-mission",
+              "multi-mission_merged"
+            ],
             "product": 	"CCMP_MEASURES_ATLAS_L4_OW_L3_5A_MONTHLY_WIND_VECTORS_FLK",
             "startDate":"1987-07-01",
             "endDate":  "2011-12-31",

--- a/common/config/wv.json/layers/multi-mission/merged/CCMP_REMSS_Scalar_Wind_Speed_Monthly.json
+++ b/common/config/wv.json/layers/multi-mission/merged/CCMP_REMSS_Scalar_Wind_Speed_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Wind Speed (Scalar, REMSS, Monthly)",
             "subtitle": "CCMP",
             "tags":     "",
+            "layergroup": [
+              "multi-mission",
+              "multi-mission_merged"
+            ],
             "product": 	"CCMP_MEASURES_ATLAS_L4_OW_L3_5A_MONTHLY_WIND_VECTORS_FLK",
             "startDate":"1987-07-01",
             "endDate":  "2011-12-31",

--- a/common/config/wv.json/layers/multi-mission/merged/CCMP_REMSS_Zonal_Wind_Speed_Monthly.json
+++ b/common/config/wv.json/layers/multi-mission/merged/CCMP_REMSS_Zonal_Wind_Speed_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Wind Speed (Zonal, REMSS, Monthly)",
             "subtitle": "CCMP",
             "tags":     "",
+            "layergroup": [
+              "multi-mission",
+              "multi-mission_merged"
+            ],
             "product": 	"CCMP_MEASURES_ATLAS_L4_OW_L3_5A_MONTHLY_WIND_VECTORS_FLK",
             "startDate":"1987-07-01",
             "endDate":  "2011-12-31",

--- a/common/config/wv.json/layers/multi-mission/merged/MEaSUREs_Ice_Velocity_Antarctica.json
+++ b/common/config/wv.json/layers/multi-mission/merged/MEaSUREs_Ice_Velocity_Antarctica.json
@@ -5,6 +5,10 @@
             "title":    "Ice Velocity (Antarctica)",
             "subtitle": "ALOS/PALSAR, ENVISAT/ASAR, ERS-1/SAR, ERS-2/SAR, RADARSAT-1/SAR, RADARSAT-2/SAR",
             "tags":     "",
+            "layergroup": [
+              "multi-mission",
+              "multi-mission_merged"
+            ],
             "product": 	"NSIDC-0484",
             "group":    "overlays",
             "startDate":"1996-01-01",

--- a/common/config/wv.json/layers/multi-mission/merged/MEaSUREs_Ice_Velocity_Greenland.json
+++ b/common/config/wv.json/layers/multi-mission/merged/MEaSUREs_Ice_Velocity_Greenland.json
@@ -5,6 +5,10 @@
             "title":    "Ice Velocity (Greenland)",
             "subtitle": "ALOS/PALSAR, RADARSAT-1/SAR, TSX/SAR",
             "tags":     "",
+            "layergroup": [
+              "multi-mission",
+              "multi-mission_merged"
+            ],
             "product": 	"NSIDC-0478",
             "group":    "overlays",
             "startDate":"2000-09-03",

--- a/common/config/wv.json/layers/multi-mission/merged/MEaSUREs_Sea_Ice_Snow_Extent.json
+++ b/common/config/wv.json/layers/multi-mission/merged/MEaSUREs_Sea_Ice_Snow_Extent.json
@@ -5,6 +5,10 @@
             "title":    "Sea Ice and Snow Extent",
             "subtitle": " DMSP 5D-2 F13/SSMI, DMSP 5D-3 F17/SSMIS, Terra/MODIS",
             "tags":     "",
+            "layergroup": [
+              "multi-mission",
+              "multi-mission_merged"
+            ],
             "product": 	"NSIDC-0534",
             "group":    "overlays",
             "startDate":"1999-01-01",

--- a/common/config/wv.json/layers/multi-mission/merged/RSS_Merged_Wind_Climatology_Monthly.json
+++ b/common/config/wv.json/layers/multi-mission/merged/RSS_Merged_Wind_Climatology_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Wind Speed over Ice-Free Oceans (Monthly, Average)",
             "subtitle": "Aqua/AMSR-E, GCOM-W1/AMSR2, DMSP-F16/SSMI, DMSP-F17/SSMI",
             "tags":     "",
+            "layergroup": [
+              "multi-mission",
+              "multi-mission_merged"
+            ],
             "product": 	"rss1windnv7r01",
             "startDate":"1988-01-01",
             "endDate":  "2016-08-31",

--- a/common/config/wv.json/layers/multi-mission/merged/RSS_Total_Precipitable_Water_Climatology_Monthly.json
+++ b/common/config/wv.json/layers/multi-mission/merged/RSS_Total_Precipitable_Water_Climatology_Monthly.json
@@ -5,6 +5,10 @@
             "title":    "Precipitable Water over Ice-Free Oceans (Monthly, Average)",
             "subtitle": "Aqua/AMSR-E, GCOM-W1/AMSR2, DMSP-F16/SSMI, DMSP-F17/SSMI",
             "tags":     "",
+            "layergroup": [
+              "multi-mission",
+              "multi-mission_merged"
+            ],
             "product": 	"rss1tpwnv7r01",
             "startDate":"1988-01-01",
             "endDate":  "2016-08-31",

--- a/common/config/wv.json/layers/multi-mission/trmm_orbview/LIS_High_Resolution_Full_Climatology_LIS_Flash_Rate_Climatology.json
+++ b/common/config/wv.json/layers/multi-mission/trmm_orbview/LIS_High_Resolution_Full_Climatology_LIS_Flash_Rate_Climatology.json
@@ -6,6 +6,10 @@
             "subtitle": "TRMM / LIS, OrbView-1 / OTD",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "multi-mission",
+              "multi-mission_trmmorbview"
+            ],
             "product":  "lohrfc",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/omi/OMI_Absorbing_Aerosol_Optical_Depth.json
+++ b/common/config/wv.json/layers/omi/OMI_Absorbing_Aerosol_Optical_Depth.json
@@ -5,6 +5,9 @@
             "title":    "Aerosol Optical Depth (Absorbing, Near-UV, 388.0 nm)",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMAERUVd",
             "tags":     "aod",
 

--- a/common/config/wv.json/layers/omi/OMI_Absorbing_Aerosol_Optical_Thickness_MW_388.json
+++ b/common/config/wv.json/layers/omi/OMI_Absorbing_Aerosol_Optical_Thickness_MW_388.json
@@ -5,6 +5,9 @@
             "title":    "Aerosol Optical Depth (Absorbing, Multi-Wavelength, 388.0 nm)",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMAEROe",
             "tags":     "aod"
 

--- a/common/config/wv.json/layers/omi/OMI_Aerosol_Index.json
+++ b/common/config/wv.json/layers/omi/OMI_Aerosol_Index.json
@@ -5,6 +5,9 @@
             "title":    "Aerosol Index",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMAERUV",
             "tags":     "ai",
 

--- a/common/config/wv.json/layers/omi/OMI_Aerosol_Optical_Depth.json
+++ b/common/config/wv.json/layers/omi/OMI_Aerosol_Optical_Depth.json
@@ -5,6 +5,9 @@
             "title":    "Aerosol Optical Depth (Extinction, Near-UV, 388.0 nm)",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMAERUVd",
             "tags":     "aod",
 

--- a/common/config/wv.json/layers/omi/OMI_Cloud_Pressure.json
+++ b/common/config/wv.json/layers/omi/OMI_Cloud_Pressure.json
@@ -5,6 +5,9 @@
             "title":    "Cloud Pressure",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMCLDRR",
 
             "palette": {

--- a/common/config/wv.json/layers/omi/OMI_Nitrogen_Dioxide_Tropo_Column.json
+++ b/common/config/wv.json/layers/omi/OMI_Nitrogen_Dioxide_Tropo_Column.json
@@ -5,6 +5,9 @@
             "title":    "Nitrogen Dioxide (Tropospheric Column)",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMNO2d",
             "tags":     "no2"
 

--- a/common/config/wv.json/layers/omi/OMI_Ozone_DOAS_Total_Column.json
+++ b/common/config/wv.json/layers/omi/OMI_Ozone_DOAS_Total_Column.json
@@ -5,6 +5,9 @@
             "title":    "Ozone (DOAS)",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMDOAO3e",
             "tags":     "Differential Absorption Spectroscopy"
 

--- a/common/config/wv.json/layers/omi/OMI_Ozone_TOMS_Total_Column.json
+++ b/common/config/wv.json/layers/omi/OMI_Ozone_TOMS_Total_Column.json
@@ -5,6 +5,9 @@
             "title":    "Ozone (TOMS-Like)",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMTO3e",
             "tags":     "Total Ozone Mapping Spectrometer"
 

--- a/common/config/wv.json/layers/omi/OMI_SO2_Lower_Troposphere.json
+++ b/common/config/wv.json/layers/omi/OMI_SO2_Lower_Troposphere.json
@@ -5,6 +5,9 @@
             "title":    "Sulfur Dioxide (Lower Troposphere)",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMSO2",
             "tags":     "so2 sulphur dioxide",
 

--- a/common/config/wv.json/layers/omi/OMI_SO2_Middle_Troposphere.json
+++ b/common/config/wv.json/layers/omi/OMI_SO2_Middle_Troposphere.json
@@ -5,6 +5,9 @@
             "title":    "Sulfur Dioxide (Middle Troposphere)",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMSO2",
             "tags":     "so2 sulphur dioxide",
 

--- a/common/config/wv.json/layers/omi/OMI_SO2_Planetary_Boundary_Layer.json
+++ b/common/config/wv.json/layers/omi/OMI_SO2_Planetary_Boundary_Layer.json
@@ -5,6 +5,9 @@
             "title":    "Sulfur Dioxide (Planetary Boundary Layer)",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMSO2e",
             "tags":     "so2 sulphur dioxide"
         }

--- a/common/config/wv.json/layers/omi/OMI_SO2_Upper_Troposphere_and_Stratosphere.json
+++ b/common/config/wv.json/layers/omi/OMI_SO2_Upper_Troposphere_and_Stratosphere.json
@@ -5,6 +5,9 @@
             "title":    "Sulfur Dioxide (Upper Troposphere and Stratosphere)",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMSO2",
             "tags":     "so2 sulphur dioxide",
 

--- a/common/config/wv.json/layers/omi/OMI_Single_Scattering_Albedo.json
+++ b/common/config/wv.json/layers/omi/OMI_Single_Scattering_Albedo.json
@@ -5,6 +5,9 @@
             "title":    "Aerosol Single Scattering Albedo (Near-UV, 388.0 nm)",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMAERUVd",
             "tags":     "ultra violet"
 

--- a/common/config/wv.json/layers/omi/OMI_UV_Erythemal_Daily_Dose.json
+++ b/common/config/wv.json/layers/omi/OMI_UV_Erythemal_Daily_Dose.json
@@ -5,6 +5,9 @@
             "title":    "UV Erythemal Daily Dose (Local Noon)",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMUVBd",
             "tags":     "ultra violet",
             "inactive": true

--- a/common/config/wv.json/layers/omi/OMI_UV_Erythemal_Dose_Rate.json
+++ b/common/config/wv.json/layers/omi/OMI_UV_Erythemal_Dose_Rate.json
@@ -5,6 +5,9 @@
             "title":    "UV Erythemal Dose Rate (Local Noon)",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMUVBd",
             "tags":     "ultra violet",
             "inactive": true

--- a/common/config/wv.json/layers/omi/OMI_UV_Index.json
+++ b/common/config/wv.json/layers/omi/OMI_UV_Index.json
@@ -5,6 +5,9 @@
             "title":    "UV Index (Local Noon)",
             "subtitle": "Aura / OMI",
             "group":    "overlays",
+            "layergroup": [
+              "omi"
+            ],
             "product":  "OMUVBd",
             "tags":     "ultra violet",
             "inactive": true

--- a/common/config/wv.json/layers/orbview/OTD_High_Resolution_Full_Climatology_OTD_Flash_Rate_Climatology.json
+++ b/common/config/wv.json/layers/orbview/OTD_High_Resolution_Full_Climatology_OTD_Flash_Rate_Climatology.json
@@ -6,6 +6,9 @@
             "subtitle": "OrbView-1 / OTD",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "orbview"
+            ],
             "product":  "lohrfc",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/orbview/OTD_High_Resolution_Full_Climatology_OTD_Raw_Flashes.json
+++ b/common/config/wv.json/layers/orbview/OTD_High_Resolution_Full_Climatology_OTD_Raw_Flashes.json
@@ -6,6 +6,9 @@
             "subtitle": "OrbView-1 / OTD",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "orbview"
+            ],
             "product":  "lohrfc",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/orbview/OTD_High_Resolution_Full_Climatology_OTD_Scaled_Flashes.json
+++ b/common/config/wv.json/layers/orbview/OTD_High_Resolution_Full_Climatology_OTD_Scaled_Flashes.json
@@ -6,6 +6,9 @@
             "subtitle": "OrbView-1 / OTD",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "orbview"
+            ],
             "product":  "lohrfc",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/reference/Coastlines.json
+++ b/common/config/wv.json/layers/reference/Coastlines.json
@@ -8,7 +8,9 @@
             "type":     "wmts",
             "tileSize": [ 512, 512 ],
             "noTransition":     "true",
-
+            "layergroup": [
+              "reference"
+            ],
             "projections": {
                 "antarctic": {
                     "subtitle":     "SCAR Antarctic Digital Database / Coastlines",

--- a/common/config/wv.json/layers/reference/Graticule.json
+++ b/common/config/wv.json/layers/reference/Graticule.json
@@ -9,7 +9,9 @@
             "tileSize": [ 512, 512 ],
             "noTransition":     "true",
             "type":     "variable",
-
+            "layergroup": [
+              "reference"
+            ],
             "projections": {
                 "arctic": {
                     "subtitle":     "Polarview / Graticule",

--- a/common/config/wv.json/layers/reference/Land_Mask.json
+++ b/common/config/wv.json/layers/reference/Land_Mask.json
@@ -8,7 +8,9 @@
             "format":   "image/png",
             "type":     "wmts",
             "tileSize": [ 512, 512 ],
-
+            "layergroup": [
+              "reference"
+            ],
             "projections": {
                 "antarctic": {
                     "layer":        "SCAR_Land_Mask",

--- a/common/config/wv.json/layers/reference/Land_Water_Map.json
+++ b/common/config/wv.json/layers/reference/Land_Water_Map.json
@@ -8,7 +8,9 @@
             "format":   "image/png",
             "type":     "wmts",
             "tileSize": [ 512, 512 ],
-
+            "layergroup": [
+              "reference"
+            ],
             "projections": {
                 "antarctic": {
                     "layer":        "SCAR_Land_Water_Map",

--- a/common/config/wv.json/layers/reference/MODIS_Aqua_Data_No_Data.json
+++ b/common/config/wv.json/layers/reference/MODIS_Aqua_Data_No_Data.json
@@ -4,7 +4,10 @@
             "id":       "MODIS_Aqua_Data_No_Data",
             "title":    "Areas of No Data (mask)",
             "subtitle": "Aqua / MODIS",
-            "group":    "overlays"
+            "group":    "overlays",
+            "layergroup": [
+              "reference"
+            ]
         }
     }
 }

--- a/common/config/wv.json/layers/reference/MODIS_Terra_Data_No_Data.json
+++ b/common/config/wv.json/layers/reference/MODIS_Terra_Data_No_Data.json
@@ -4,7 +4,10 @@
             "id":       "MODIS_Terra_Data_No_Data",
             "title":    "Areas of No Data (mask)",
             "subtitle": "Terra / MODIS",
-            "group":    "overlays"
+            "group":    "overlays",
+            "layergroup": [
+              "reference"
+            ]
         }
     }
 }

--- a/common/config/wv.json/layers/reference/MODIS_Water_Mask.json
+++ b/common/config/wv.json/layers/reference/MODIS_Water_Mask.json
@@ -6,7 +6,9 @@
             "subtitle": "Terra / MODIS, SRTM",
             "tags":     "mask",
             "group":    "overlays",
-            
+            "layergroup": [
+              "reference"
+            ],
             "palette": {
                 "id":     "MODIS_Water_Mask"
             }

--- a/common/config/wv.json/layers/reference/Reference_Features.json
+++ b/common/config/wv.json/layers/reference/Reference_Features.json
@@ -8,7 +8,10 @@
             "group":    "overlays",
             "type":     "wmts",
             "tags":     "country, countries, state, province",
-            "noTransition":     "true"
+            "noTransition":     "true",
+            "layergroup": [
+              "reference"
+            ]
         }
     }
 }

--- a/common/config/wv.json/layers/reference/Reference_Labels.json
+++ b/common/config/wv.json/layers/reference/Reference_Labels.json
@@ -8,7 +8,10 @@
             "group":    "overlays",
             "type":     "wmts",
             "tags":     "country, countries, state, province, cities, city",
-            "noTransition":     "true"
+            "noTransition":     "true",
+            "layergroup": [
+              "reference"
+            ]
         }
     }
 }

--- a/common/config/wv.json/layers/reference/arctic_coastlines.json
+++ b/common/config/wv.json/layers/reference/arctic_coastlines.json
@@ -9,7 +9,9 @@
             "format":   "image/png",
             "type":     "wmts",
             "tileSize": [ 512, 512 ],
-
+            "layergroup": [
+              "reference"
+            ],
             "noTransition":     "true",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/arctic_graticule.json
+++ b/common/config/wv.json/layers/reference/arctic_graticule.json
@@ -9,7 +9,9 @@
             "format":   "image/png",
             "type":     "wmts",
             "tileSize": [ 512, 512 ],
-
+            "layergroup": [
+              "reference"
+            ],
             "noTransition":     "true",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/blue_marble/BlueMarble_NextGeneration.json
+++ b/common/config/wv.json/layers/reference/blue_marble/BlueMarble_NextGeneration.json
@@ -5,7 +5,11 @@
             "title":    "Blue Marble (August 2004)",
             "subtitle": "MODIS / NASA Earth Observatory",
             "tags":     "bm bmng",
-            "group":    "baselayers"
+            "group":    "baselayers",
+            "layergroup": [
+              "reference",
+              "reference_bluemarble"
+            ]
         }
     }
 }

--- a/common/config/wv.json/layers/reference/blue_marble/BlueMarble_ShadedRelief.json
+++ b/common/config/wv.json/layers/reference/blue_marble/BlueMarble_ShadedRelief.json
@@ -5,7 +5,11 @@
             "title":    "Blue Marble (August 2004, Shaded Relief)",
             "subtitle": "MODIS / NASA Earth Observatory",
             "tags":     "bm bmng",
-            "group":    "baselayers"
+            "group":    "baselayers",
+            "layergroup": [
+              "reference",
+              "reference_bluemarble"
+            ]
         }
     }
 }

--- a/common/config/wv.json/layers/reference/blue_marble/BlueMarble_ShadedRelief_Bathymetry.json
+++ b/common/config/wv.json/layers/reference/blue_marble/BlueMarble_ShadedRelief_Bathymetry.json
@@ -5,7 +5,11 @@
             "title":    "Blue Marble (August 2004, Shaded Relief and Bathymetry)",
             "subtitle": "MODIS / NASA Earth Observatory",
             "tags":     "bm bmng",
-            "group":    "baselayers"
+            "group":    "baselayers",
+            "layergroup": [
+              "reference",
+              "reference_bluemarble"
+            ]
         }
     }
 }

--- a/common/config/wv.json/layers/reference/orbits/Aqua_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/Aqua_Orbit_Asc.json
@@ -4,13 +4,19 @@
             "id":       "Aqua_Orbit_Asc",
             "title":    "Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / Aqua",
+            "description": "reference/orbits/Aqua_Orbit_Asc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
             "wrapadjacentdays": true,
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "day",
+            "track": "ascending",
             "startDate": "2002-05-04",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/Aqua_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/Aqua_Orbit_Dsc.json
@@ -4,12 +4,18 @@
             "id":       "Aqua_Orbit_Dsc",
             "title":    "Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / Aqua",
+            "description": "reference/orbits/Aqua_Orbit_Dsc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "night",
+            "track": "descending",
             "startDate": "2002-05-04",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/Aura_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/Aura_Orbit_Asc.json
@@ -4,13 +4,19 @@
             "id":       "Aura_Orbit_Asc",
             "title":    "Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / Aura",
+            "description": "reference/orbits/Aura_Orbit_Asc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
             "wrapadjacentdays": true,
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "day",
+            "track": "ascending",
             "startDate": "2004-07-15",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/Aura_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/Aura_Orbit_Dsc.json
@@ -4,12 +4,18 @@
             "id":       "Aura_Orbit_Dsc",
             "title":    "Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / Aura",
+            "description": "reference/orbits/Aura_Orbit_Dsc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "night",
+            "track": "descending",
             "startDate": "2004-07-15",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/Calipso_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/Calipso_Orbit_Asc.json
@@ -4,13 +4,19 @@
             "id":       "Calipso_Orbit_Asc",
             "title":    "Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / CALIPSO",
+            "description": "reference/orbits/Calipso_Orbit_Asc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
             "wrapadjacentdays": true,
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "day",
+            "track": "ascending",
             "startDate": "2006-04-28",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/Calipso_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/Calipso_Orbit_Dsc.json
@@ -4,12 +4,18 @@
             "id":       "Calipso_Orbit_Dsc",
             "title":    "Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / CALIPSO",
+            "description": "reference/orbits/Calipso_Orbit_Dsc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "night",
+            "track": "descending",
             "startDate": "2006-04-28",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/GCOM_W1_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/GCOM_W1_Orbit_Asc.json
@@ -4,13 +4,19 @@
             "id":       "GCOM_W1_Orbit_Asc",
             "title":    "Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / GCOM-W1",
+            "description": "reference/orbits/GCOM_W1_Orbit_Asc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
             "wrapadjacentdays": true,
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "day",
+            "track": "ascending",
             "startDate": "2012-05-17",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/GCOM_W1_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/GCOM_W1_Orbit_Dsc.json
@@ -4,12 +4,18 @@
             "id":       "GCOM_W1_Orbit_Dsc",
             "title":    "Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / GCOM-W1",
+            "description": "reference/orbits/GCOM_W1_Orbit_Dsc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "night",
+            "track": "descending",
             "startDate": "2012-05-17",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/GOSAT_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/GOSAT_Orbit_Asc.json
@@ -4,12 +4,18 @@
             "id":       "GOSAT_Orbit_Asc",
             "title":    "Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / GOSAT",
+            "description": "",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "day",
+            "track": "ascending",
             "startDate": "2009-01-23",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/GOSAT_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/GOSAT_Orbit_Dsc.json
@@ -4,12 +4,18 @@
             "id":       "GOSAT_Orbit_Dsc",
             "title":    "Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / GOSAT",
+            "description": "",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "night",
+            "track": "descending",
             "startDate": "2009-01-23",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/GPM_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/GPM_Orbit_Asc.json
@@ -4,12 +4,18 @@
             "id":       "GPM_Orbit_Asc",
             "title":    "Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / GPM",
+            "description": "reference/orbits/GPM_Orbit_Asc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "day",
+            "track": "ascending",
             "startDate": "2014-02-27",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/GPM_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/GPM_Orbit_Dsc.json
@@ -4,12 +4,18 @@
             "id":       "GPM_Orbit_Dsc",
             "title":    "Orbital Track (Descending/Day)",
             "subtitle": "Space-Track.org / GPM",
+            "description": "reference/orbits/GPM_Orbit_Dsc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "day",
+            "track": "descending",
             "startDate": "2014-02-27",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/ISS_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/ISS_Orbit_Asc.json
@@ -4,13 +4,19 @@
             "id":       "ISS_Orbit_Asc",
             "title":    "Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / Int'l Space Station",
+            "description": "",
             "tags":     "iss international",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "day",
+            "track": "ascending",
             "startDate": "1998-11-20",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/ISS_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/ISS_Orbit_Dsc.json
@@ -4,13 +4,19 @@
             "id":       "ISS_Orbit_Dsc",
             "title":    "Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / Int'l Space Station",
+            "description": "",
             "tags":     "iss international",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "night",
+            "track": "descending",
             "startDate": "1998-11-20",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/Landsat_8_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/Landsat_8_Orbit_Asc.json
@@ -4,12 +4,18 @@
             "id":       "Landsat_8_Orbit_Asc",
             "title":    "Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / Landsat 8",
+            "description": "",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "day",
+            "track": "ascending",
             "startDate": "2013-02-11",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/Landsat_8_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/Landsat_8_Orbit_Dsc.json
@@ -4,12 +4,18 @@
             "id":       "Landsat_8_Orbit_Dsc",
             "title":    "Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / Landsat 8",
+            "description": "",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "night",
+            "track": "descending",
             "startDate": "2013-02-11",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/OCO_2_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/OCO_2_Orbit_Asc.json
@@ -4,13 +4,19 @@
             "id":       "OCO_2_Orbit_Asc",
             "title":    "Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / OCO-2",
+            "description": "",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
             "wrapadjacentdays": true,
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "day",
+            "track": "ascending",
             "startDate": "2014-07-02",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/OCO_2_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/OCO_2_Orbit_Dsc.json
@@ -4,12 +4,18 @@
             "id":       "OCO_2_Orbit_Dsc",
             "title":    "Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / OCO-2",
+            "description": "",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "night",
+            "track": "descending",
             "startDate": "2014-07-02",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/SMAP_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/SMAP_Orbit_Asc.json
@@ -4,12 +4,18 @@
             "id":       "SMAP_Orbit_Asc",
             "title":    "Orbital Track (Ascending/Night)",
             "subtitle": "Space-Track.org / SMAP",
+            "description": "",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "night",
+            "track": "ascending",
             "startDate": "2012-05-08",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/SMAP_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/SMAP_Orbit_Dsc.json
@@ -4,12 +4,18 @@
             "id":       "SMAP_Orbit_Dsc",
             "title":    "Orbital Track (Descending/Day)",
             "subtitle": "Space-Track.org / SMAP",
+            "description": "",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "day",
+            "track": "descending",
             "startDate": "2012-05-08",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/Suomi_NPP_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/Suomi_NPP_Orbit_Asc.json
@@ -4,6 +4,7 @@
             "id":       "Suomi_NPP_Orbit_Asc",
             "title":    "Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / Suomi NPP",
+            "description": "reference/orbits/Suomi_NPP_Orbit_Asc",
             "group":    "overlays",
             "tags":     "snpp s-npp",
             "format":   "image/png",
@@ -11,7 +12,12 @@
             "tileSize": [512, 512],
             "period":   "daily",
             "wrapadjacentdays": true,
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "day",
+            "track": "ascending",
             "startDate": "2011-10-28",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/Suomi_NPP_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/Suomi_NPP_Orbit_Dsc.json
@@ -4,13 +4,19 @@
             "id":       "Suomi_NPP_Orbit_Dsc",
             "title":    "Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / Suomi NPP",
+            "description": "reference/orbits/Suomi_NPP_Orbit_Dsc",
             "group":    "overlays",
             "tags":     "snpp s-npp",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "night",
+            "track": "descending",
             "startDate": "2011-10-28",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/Terra_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/Terra_Orbit_Asc.json
@@ -4,12 +4,18 @@
             "id":       "Terra_Orbit_Asc",
             "title":    "Orbital Track (Ascending/Night)",
             "subtitle": "Space-Track.org / Terra",
+            "description": "reference/orbits/Terra_Orbit_Asc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "night",
+            "track": "ascending",
             "startDate": "2000-02-24",
 
             "projections": {

--- a/common/config/wv.json/layers/reference/orbits/Terra_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/Terra_Orbit_Dsc.json
@@ -4,13 +4,19 @@
             "id":       "Terra_Orbit_Dsc",
             "title":    "Orbital Track (Descending/Day)",
             "subtitle": "Space-Track.org / Terra",
+            "description": "reference/orbits/Terra_Orbit_Dsc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",
             "tileSize": [512, 512],
             "period":   "daily",
             "wrapadjacentdays": true,
-
+            "layergroup": [
+              "reference",
+              "reference_orbits"
+            ],
+            "daynight": "day",
+            "track": "descending",
             "startDate": "2000-02-24",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/energy-pop-exposure-nuclear-plants-locations_plants.json
+++ b/common/config/wv.json/layers/sedac/energy-pop-exposure-nuclear-plants-locations_plants.json
@@ -9,6 +9,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_SEDAC_ENERGY_NPPL",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/grand-v1-dams-rev01.json
+++ b/common/config/wv.json/layers/sedac/grand-v1-dams-rev01.json
@@ -9,6 +9,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_SEDAC_GRanD_DAMS",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/grand-v1-reservoirs-rev01.json
+++ b/common/config/wv.json/layers/sedac/grand-v1-reservoirs-rev01.json
@@ -9,6 +9,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_SEDAC_GRanD_RESERVOIRS",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/grump-v1-population-count_2000.json
+++ b/common/config/wv.json/layers/sedac/grump-v1-population-count_2000.json
@@ -8,6 +8,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_SEDAC_GRUMPv1_POPCOUNT",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/grump-v1-settlement-points.json
+++ b/common/config/wv.json/layers/sedac/grump-v1-settlement-points.json
@@ -10,6 +10,9 @@
             "tileSize": [512, 512],
             "type":     "wms",
             "styles":   "grump-v1-settlement-points:scale-dependent",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_SEDAC_GRUMPv1_STLMNT",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/grump-v1-urban-extents.json
+++ b/common/config/wv.json/layers/sedac/grump-v1-urban-extents.json
@@ -9,6 +9,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_SEDAC_GRUMPv1_EXT",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/lecz-urban-rural-population-land-area-estimates-v2_urban-rural-zones-10m.json
+++ b/common/config/wv.json/layers/sedac/lecz-urban-rural-population-land-area-estimates-v2_urban-rural-zones-10m.json
@@ -9,6 +9,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_SEDAC_LECZ_URPLAEv2",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/lulc-global-mangrove-forests-distribution-2000.json
+++ b/common/config/wv.json/layers/sedac/lulc-global-mangrove-forests-distribution-2000.json
@@ -9,6 +9,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_SEDAC_LULC_MANGROVES_2000",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/ndh-cyclone-hazard-frequency-distribution.json
+++ b/common/config/wv.json/layers/sedac/ndh-cyclone-hazard-frequency-distribution.json
@@ -8,6 +8,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_CHRR_NDH_CYCLONE_HFD",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/ndh-cyclone-mortality-risks-distribution.json
+++ b/common/config/wv.json/layers/sedac/ndh-cyclone-mortality-risks-distribution.json
@@ -8,6 +8,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_CHRR_NDH_CYCLONE_MRD",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/ndh-cyclone-proportional-economic-loss-risk-deciles.json
+++ b/common/config/wv.json/layers/sedac/ndh-cyclone-proportional-economic-loss-risk-deciles.json
@@ -8,6 +8,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_CHRR_NDH_CYCLONE_PELRD",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/ndh-drought-hazard-frequency-distribution.json
+++ b/common/config/wv.json/layers/sedac/ndh-drought-hazard-frequency-distribution.json
@@ -8,6 +8,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_CHRR_NDH_DROUGHT_HFD",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/ndh-drought-mortality-risks-distribution.json
+++ b/common/config/wv.json/layers/sedac/ndh-drought-mortality-risks-distribution.json
@@ -8,6 +8,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_CHRR_NDH_DROUGHT_MRD",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/ndh-drought-proportional-economic-loss-risk-deciles.json
+++ b/common/config/wv.json/layers/sedac/ndh-drought-proportional-economic-loss-risk-deciles.json
@@ -8,6 +8,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_CHRR_NDH_DROUGHT_PELRD",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/ndh-flood-hazard-frequency-distribution.json
+++ b/common/config/wv.json/layers/sedac/ndh-flood-hazard-frequency-distribution.json
@@ -8,6 +8,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_CHRR_NDH_FLOOD_HFD",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/ndh-flood-mortality-risks-distribution.json
+++ b/common/config/wv.json/layers/sedac/ndh-flood-mortality-risks-distribution.json
@@ -8,6 +8,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_CHRR_NDH_FLOOD_MRD",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/ndh-flood-proportional-economic-loss-risk-deciles.json
+++ b/common/config/wv.json/layers/sedac/ndh-flood-proportional-economic-loss-risk-deciles.json
@@ -8,6 +8,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_CHRR_NDH_FLOOD_PELRD",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/ndh-volcano-hazard-frequency-distribution.json
+++ b/common/config/wv.json/layers/sedac/ndh-volcano-hazard-frequency-distribution.json
@@ -8,6 +8,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_CHRR_NDH_VOLCANO_HFD",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/ndh-volcano-mortality-risks-distribution.json
+++ b/common/config/wv.json/layers/sedac/ndh-volcano-mortality-risks-distribution.json
@@ -8,6 +8,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_CHRR_NDH_VOLCANO_MRD",
 
             "projections": {

--- a/common/config/wv.json/layers/sedac/ndh-volcano-proportional-economic-loss-risk-deciles.json
+++ b/common/config/wv.json/layers/sedac/ndh-volcano-proportional-economic-loss-risk-deciles.json
@@ -8,6 +8,9 @@
             "format":   "image/png",
             "tileSize": [512, 512],
             "type":     "wms",
+            "layergroup": [
+              "sedac"
+            ],
             "product":  "CIESIN_CHRR_NDH_VOLCANO_PELRD",
 
             "projections": {

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_H.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_H.json
@@ -5,6 +5,9 @@
             "title":    "Uncorrected Brightness Temperature 36 km (L1, Passive, Aft, H Polarization)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_H_QA.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_H_QA.json
@@ -5,6 +5,9 @@
             "title":    "Uncorrected Brightness Temperature 36 km QA (L1, Passive, Aft, H Polarization)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_H_RFI.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_H_RFI.json
@@ -5,6 +5,9 @@
             "title":    "Uncorrected Brightness Temperature 36 km RFI (L1, Passive, Aft, H Polarization)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_V.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_V.json
@@ -5,6 +5,9 @@
             "title":    "Uncorrected Brightness Temperature 36 km (L1, Passive, Aft, V Polarization)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_V_QA.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_V_QA.json
@@ -5,6 +5,9 @@
             "title":    "Uncorrected Brightness Temperature 36 km QA (L1, Passive, Aft, V Polarization)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_V_RFI.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_V_RFI.json
@@ -5,6 +5,9 @@
             "title":    "Uncorrected Brightness Temperature 36 km RFI (L1, Passive, Aft, V Polarization)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_H.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_H.json
@@ -5,6 +5,9 @@
             "title":    "Uncorrected Brightness Temperature 36 km (L1, Passive, Fore, H Polarization)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_H_QA.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_H_QA.json
@@ -5,6 +5,9 @@
             "title":    "Uncorrected Brightness Temperature 36 km QA (L1, Passive, Fore, H Polarization)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_H_RFI.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_H_RFI.json
@@ -5,6 +5,9 @@
             "title":    "Uncorrected Brightness Temperature 36 km RFI (L1, Passive, Fore, H Polarization)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_V.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_V.json
@@ -5,6 +5,9 @@
             "title":    "Uncorrected Brightness Temperature 36 km (L1, Passive, Fore, V Polarization)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_V_QA.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_V_QA.json
@@ -5,6 +5,9 @@
             "title":    "Uncorrected Brightness Temperature 36 km QA (L1, Passive, Fore, V Polarization)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_V_RFI.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_V_RFI.json
@@ -5,6 +5,9 @@
             "title":    "Uncorrected Brightness Temperature 36 km RFI (L1, Passive, Fore, V Polarization)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_H.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_H.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_H_QA.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_H_QA.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_H_RFI.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_H_RFI.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_V.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_V.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_V_QA.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_V_QA.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_V_RFI.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_V_RFI.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_H.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_H.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_H_QA.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_H_QA.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_H_RFI.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_H_RFI.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_V.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_V.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_V_QA.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_V_QA.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_V_RFI.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_V_RFI.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1CTB_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Faraday_Rotation_Aft.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Faraday_Rotation_Aft.json
@@ -5,6 +5,9 @@
             "title":    "Faraday Rotation Angle (L1, Passive, Aft)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1BTB"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L1_Passive_Faraday_Rotation_Fore.json
+++ b/common/config/wv.json/layers/smap/SMAP_L1_Passive_Faraday_Rotation_Fore.json
@@ -5,6 +5,9 @@
             "title":    "Faraday Rotation Angle (L1, Passive, Fore)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL1BTB"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L2_Passive_Day_Soil_Moisture_Option1.json
+++ b/common/config/wv.json/layers/smap/SMAP_L2_Passive_Day_Soil_Moisture_Option1.json
@@ -5,6 +5,9 @@
             "title":    "Soil Moisture 36 km (L2, Passive, Day, Single Channel Algorithm, H-pol)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL2SMP"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L2_Passive_Day_Soil_Moisture_Option2.json
+++ b/common/config/wv.json/layers/smap/SMAP_L2_Passive_Day_Soil_Moisture_Option2.json
@@ -5,6 +5,9 @@
             "title":    "Soil Moisture 36 km (L2, Passive, Day, Single Channel Algorithm, V-pol)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL2SMP"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L2_Passive_Day_Soil_Moisture_Option3.json
+++ b/common/config/wv.json/layers/smap/SMAP_L2_Passive_Day_Soil_Moisture_Option3.json
@@ -5,6 +5,9 @@
             "title":    "Soil Moisture 36 km (L2, Passive, Day, Dual Channel Algorithm)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL2SMP"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L2_Passive_Enhanced_Day_Soil_Moisture_Option1.json
+++ b/common/config/wv.json/layers/smap/SMAP_L2_Passive_Enhanced_Day_Soil_Moisture_Option1.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL2SMP_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L2_Passive_Enhanced_Day_Soil_Moisture_Option2.json
+++ b/common/config/wv.json/layers/smap/SMAP_L2_Passive_Enhanced_Day_Soil_Moisture_Option2.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL2SMP_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L2_Passive_Enhanced_Day_Soil_Moisture_Option3.json
+++ b/common/config/wv.json/layers/smap/SMAP_L2_Passive_Enhanced_Day_Soil_Moisture_Option3.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL2SMP_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L2_Passive_Enhanced_Night_Soil_Moisture_Option1.json
+++ b/common/config/wv.json/layers/smap/SMAP_L2_Passive_Enhanced_Night_Soil_Moisture_Option1.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL2SMP_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L2_Passive_Enhanced_Night_Soil_Moisture_Option2.json
+++ b/common/config/wv.json/layers/smap/SMAP_L2_Passive_Enhanced_Night_Soil_Moisture_Option2.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL2SMP_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L2_Passive_Enhanced_Night_Soil_Moisture_Option3.json
+++ b/common/config/wv.json/layers/smap/SMAP_L2_Passive_Enhanced_Night_Soil_Moisture_Option3.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "tags":     "enhanced",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL2SMP_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L2_Passive_Night_Soil_Moisture_Option1.json
+++ b/common/config/wv.json/layers/smap/SMAP_L2_Passive_Night_Soil_Moisture_Option1.json
@@ -5,6 +5,9 @@
             "title":    "Soil Moisture 36 km (L2, Passive, Night, Single Channel Algorithm, H-pol)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL2SMP"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L2_Passive_Night_Soil_Moisture_Option2.json
+++ b/common/config/wv.json/layers/smap/SMAP_L2_Passive_Night_Soil_Moisture_Option2.json
@@ -5,6 +5,9 @@
             "title":    "Soil Moisture 36 km (L2, Passive, Night, Single Channel Algorithm, V-pol)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL2SMP"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L2_Passive_Night_Soil_Moisture_Option3.json
+++ b/common/config/wv.json/layers/smap/SMAP_L2_Passive_Night_Soil_Moisture_Option3.json
@@ -5,6 +5,9 @@
             "title":    "Soil Moisture 36 km (L2, Passive, Night, Dual Channel Algorithm)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL2SMP"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Active_Day_Freeze_Thaw.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Active_Day_Freeze_Thaw.json
@@ -5,6 +5,9 @@
             "title":    "Freeze/Thaw 3 km (L3, Active, Day)",
             "subtitle": "SMAP / Radar",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3FTA",
             "inactive": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Active_Passive_Brightness_Temp_H.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Active_Passive_Brightness_Temp_H.json
@@ -5,6 +5,9 @@
             "title":    "Disaggregated Brightness Temperature 9 km (L3, Active/Passive, H Polarization)",
             "subtitle": "SMAP / Radar + Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3SMAP",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/smap/SMAP_L3_Active_Passive_Brightness_Temp_V.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Active_Passive_Brightness_Temp_V.json
@@ -5,6 +5,9 @@
             "title":    "Disaggregated Brightness Temperature 9 km (L3, Active/Passive, V Polarization)",
             "subtitle": "SMAP / Radar + Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3SMAP",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/smap/SMAP_L3_Active_Passive_Soil_Moisture.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Active_Passive_Soil_Moisture.json
@@ -5,6 +5,9 @@
             "title":    "Soil Moisture 9 km (L3, Active/Passive)",
             "subtitle": "SMAP / Radar + Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3SMAP",
             "wrapadjacentdays": true,
             "inactive": true

--- a/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_HH.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_HH.json
@@ -5,6 +5,9 @@
             "title":    "Sigma0 3 km (L3, Active, HH Polarization)",
             "subtitle": "SMAP / Radar",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "inactive": true,
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_HH_QA.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_HH_QA.json
@@ -5,9 +5,11 @@
             "title":    "Sigma0 3 km QA (L3, Active, HH Polarization)",
             "subtitle": "SMAP / Radar",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "inactive": true,
             "wrapadjacentdays": true
-
         }
     }
 }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_HH_RFI.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_HH_RFI.json
@@ -5,6 +5,9 @@
             "title":    "Sigma0 3 km RFI (L3, Active, HH Polarization)",
             "subtitle": "SMAP / Radar",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "inactive": true,
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_VV.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_VV.json
@@ -5,6 +5,9 @@
             "title":    "Sigma0 3 km (L3, Active, VV Polarization)",
             "subtitle": "SMAP / Radar",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "inactive": true,
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_VV_QA.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_VV_QA.json
@@ -5,6 +5,9 @@
             "title":    "Sigma0 3 km QA (L3, Active, VV Polarization)",
             "subtitle": "SMAP / Radar",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "inactive": true,
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_VV_RFI.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_VV_RFI.json
@@ -5,6 +5,9 @@
             "title":    "Sigma0 3 km RFI (L3, Active, VV Polarization)",
             "subtitle": "SMAP / Radar",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "inactive": true,
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_XPOL.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_XPOL.json
@@ -5,6 +5,9 @@
             "title":    "Sigma0 3 km (L3, Active, XPOL Polarization)",
             "subtitle": "SMAP / Radar",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "inactive": true,
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_XPOL_QA.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_XPOL_QA.json
@@ -5,6 +5,9 @@
             "title":    "Sigma0 3 km QA (L3, Active, XPOL Polarization)",
             "subtitle": "SMAP / Radar",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "inactive": true,
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_XPOL_RFI.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Active_Sigma0_XPOL_RFI.json
@@ -5,6 +5,9 @@
             "title":    "Sigma0 3 km RFI (L3, Active, XPOL Polarization)",
             "subtitle": "SMAP / Radar",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "inactive": true,
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Active_Soil_Moisture.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Active_Soil_Moisture.json
@@ -5,6 +5,9 @@
             "title":    "Soil Moisture 3 km (L3, Active)",
             "subtitle": "SMAP / Radar",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3SMA",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/smap/SMAP_L3_Passive_Brightness_Temp_H.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Passive_Brightness_Temp_H.json
@@ -5,6 +5,9 @@
             "title":    "Corrected Brightness Temperature (L3, Passive, H Polarization)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3SMP",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Passive_Brightness_Temp_V.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Passive_Brightness_Temp_V.json
@@ -5,6 +5,9 @@
             "title":    "Corrected Brightness Temperature (L3, Passive, V Polarization)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3SMP",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Passive_Day_Freeze_Thaw.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Passive_Day_Freeze_Thaw.json
@@ -5,6 +5,9 @@
             "title":    "Freeze/Thaw 36 km (L3, Passive, Day)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3FTP"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Passive_Day_Soil_Moisture.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Passive_Day_Soil_Moisture.json
@@ -5,6 +5,9 @@
             "title":    "Soil Moisture 36 km (L3, Passive, Day)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3SMP",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Passive_Enhanced_Day_Freeze_Thaw.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Passive_Enhanced_Day_Freeze_Thaw.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
             "tags":     "enhanced",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3FTP_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Passive_Enhanced_Day_Soil_Moisture.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Passive_Enhanced_Day_Soil_Moisture.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
             "tags":     "enhanced",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3SMP",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Passive_Enhanced_Night_Freeze_Thaw.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Passive_Enhanced_Night_Freeze_Thaw.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
             "tags":     "enhanced",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3FTP_E"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Passive_Enhanced_Night_Soil_Moisture.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Passive_Enhanced_Night_Soil_Moisture.json
@@ -6,6 +6,9 @@
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
             "tags":     "enhanced",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3SMP",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Passive_Night_Freeze_Thaw.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Passive_Night_Freeze_Thaw.json
@@ -5,6 +5,9 @@
             "title":    "Freeze/Thaw 36 km (L3, Passive, Night)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3FTP"
         }
     }

--- a/common/config/wv.json/layers/smap/SMAP_L3_Passive_Night_Soil_Moisture.json
+++ b/common/config/wv.json/layers/smap/SMAP_L3_Passive_Night_Soil_Moisture.json
@@ -5,6 +5,9 @@
             "title":    "Soil Moisture 36 km (L3, Passive, Night)",
             "subtitle": "SMAP / Radiometer",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL3SMP",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L4_Analyzed_Root_Zone_Soil_Moisture.json
+++ b/common/config/wv.json/layers/smap/SMAP_L4_Analyzed_Root_Zone_Soil_Moisture.json
@@ -5,6 +5,9 @@
             "title":    "Root Zone Soil Moisture 9 km (L4, 12z Instantaneous)",
             "subtitle": "SMAP / Model Value-Added",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL4SMAU",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L4_Analyzed_Surface_Soil_Moisture.json
+++ b/common/config/wv.json/layers/smap/SMAP_L4_Analyzed_Surface_Soil_Moisture.json
@@ -5,6 +5,9 @@
             "title":    "Surface Soil Moisture 9 km (L4, 12z Instantaneous)",
             "subtitle": "SMAP / Model Value-Added",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL4SMAU",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L4_Emult_Average.json
+++ b/common/config/wv.json/layers/smap/SMAP_L4_Emult_Average.json
@@ -5,6 +5,9 @@
             "title":    "Percent of Potential Vegetation Light Use Efficiency (L4, 9 km Grid Cell Mean)",
             "subtitle": "SMAP / Model Value-Added",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL4CMDL",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L4_Frozen_Area.json
+++ b/common/config/wv.json/layers/smap/SMAP_L4_Frozen_Area.json
@@ -5,6 +5,9 @@
             "title":    "Percent Frozen Area (L4, 9 km Grid Cell Coverage)",
             "subtitle": "SMAP / Model Value-Added",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL4CMDL",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L4_Mean_Gross_Primary_Productivity.json
+++ b/common/config/wv.json/layers/smap/SMAP_L4_Mean_Gross_Primary_Productivity.json
@@ -5,6 +5,9 @@
             "title":    "Gross Primary Production (L4, 9 km Grid Cell Mean)",
             "subtitle": "SMAP / Model Value-Added",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL4CMDL",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L4_Mean_Heterotrophic_Respiration.json
+++ b/common/config/wv.json/layers/smap/SMAP_L4_Mean_Heterotrophic_Respiration.json
@@ -5,6 +5,9 @@
             "title":    "Heterotrophic Respiration (L4, 9 km Grid Cell Mean)",
             "subtitle": "SMAP / Model Value-Added",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL4CMDL",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L4_Mean_Net_Ecosystem_Exchange.json
+++ b/common/config/wv.json/layers/smap/SMAP_L4_Mean_Net_Ecosystem_Exchange.json
@@ -5,6 +5,9 @@
             "title":    "Net Ecosystem CO2 Exchange (L4, 9 km Grid Cell Mean)",
             "subtitle": "SMAP / Model Value-Added",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL4CMDL",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L4_Snow_Mass.json
+++ b/common/config/wv.json/layers/smap/SMAP_L4_Snow_Mass.json
@@ -5,6 +5,9 @@
             "title":    "Snow Mass 9 km (L4, 12z-3z Average)",
             "subtitle": "SMAP / Model Value-Added",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL4SMGP",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L4_Soil_Temperature_Layer_1.json
+++ b/common/config/wv.json/layers/smap/SMAP_L4_Soil_Temperature_Layer_1.json
@@ -5,6 +5,9 @@
             "title":    "Surface Soil Temperature 9 km (L4, 12z Instantaneous)",
             "subtitle": "SMAP / Model Value-Added",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL4SMAU",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L4_Uncertainty_Analyzed_Root_Zone_Soil_Moisture.json
+++ b/common/config/wv.json/layers/smap/SMAP_L4_Uncertainty_Analyzed_Root_Zone_Soil_Moisture.json
@@ -5,6 +5,9 @@
             "title":    "Root Zone Soil Moisture Uncertainty 9 km (L4, 12z Instantaneous)",
             "subtitle": "SMAP / Model Value-Added",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL4SMAU",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L4_Uncertainty_Analyzed_Surface_Soil_Moisture.json
+++ b/common/config/wv.json/layers/smap/SMAP_L4_Uncertainty_Analyzed_Surface_Soil_Moisture.json
@@ -5,6 +5,9 @@
             "title":    "Surface Soil Moisture Uncertainty 9 km (L4, 12z Instantaneous)",
             "subtitle": "SMAP / Model Value-Added",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL4SMAU",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/smap/SMAP_L4_Uncertainty_Mean_Net_Ecosystem_Exchange.json
+++ b/common/config/wv.json/layers/smap/SMAP_L4_Uncertainty_Mean_Net_Ecosystem_Exchange.json
@@ -5,6 +5,9 @@
             "title":    "Net Ecosystem CO2 Exchange Uncertainty 9 km (L4, 9 km Grid Cell Mean)",
             "subtitle": "SMAP / Model Value-Added",
             "group":    "overlays",
+            "layergroup": [
+              "smap"
+            ],
             "product":  "SPL4CMDL",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/srtm/SRTM_Color_Index.json
+++ b/common/config/wv.json/layers/srtm/SRTM_Color_Index.json
@@ -7,6 +7,9 @@
             "tags":     "srtm gdem",
             "group":    "overlays",
             "type":     "wmts",
+            "layergroup": [
+              "srtm"
+            ],
             "product":  "SRTMGL1",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMIS_Sea_Ice_Concentration.json
+++ b/common/config/wv.json/layers/ssmi/SSMIS_Sea_Ice_Concentration.json
@@ -6,6 +6,9 @@
             "subtitle": "NIMBUS-7/SSMR, DMSP 5D-2 F8/SSMI, DMSP 5D-2 F11/SSMI, DMSP 5D-2 F13/SSMI, DMSP 5D-3 F17/SSMIS, DMSP 5D-3 F18/SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "NSIDC-0051-0081"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMIS_Sea_Ice_Concentration_Snow_Extent.json
+++ b/common/config/wv.json/layers/ssmi/SSMIS_Sea_Ice_Concentration_Snow_Extent.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP 5D-3 F17 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "NISE"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Cloud_Liquid_Water_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Cloud_Liquid_Water_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F10 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif10d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Cloud_Liquid_Water_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Cloud_Liquid_Water_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F10 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif10d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Rain_Rate_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Rain_Rate_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F10 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif10d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Rain_Rate_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Rain_Rate_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F10 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif10d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Water_Vapor_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Water_Vapor_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F10 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif10d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Water_Vapor_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Water_Vapor_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F10 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif10d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Wind_Speed_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Wind_Speed_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F10 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif10d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Wind_Speed_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F10_Wind_Speed_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F10 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif10d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Cloud_Liquid_Water_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Cloud_Liquid_Water_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F11 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif11d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Cloud_Liquid_Water_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Cloud_Liquid_Water_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F11 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif11d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Rain_Rate_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Rain_Rate_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F11 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif11d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Rain_Rate_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Rain_Rate_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F11 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif11d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Water_Vapor_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Water_Vapor_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F11 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif11d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Water_Vapor_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Water_Vapor_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F11 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif11d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Wind_Speed_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Wind_Speed_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F11 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif11d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Wind_Speed_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F11_Wind_Speed_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F11 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif11d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Cloud_Liquid_Water_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Cloud_Liquid_Water_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F13 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif13d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Cloud_Liquid_Water_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Cloud_Liquid_Water_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F13 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif13d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Rain_Rate_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Rain_Rate_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F13 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif13d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Rain_Rate_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Rain_Rate_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F13 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif13d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Water_Vapor_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Water_Vapor_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F13 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif13d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Water_Vapor_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Water_Vapor_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F13 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif13d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Wind_Speed_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Wind_Speed_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F13 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif13d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Wind_Speed_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F13_Wind_Speed_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F13 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif13d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Cloud_Liquid_Water_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Cloud_Liquid_Water_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F14 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif14d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Cloud_Liquid_Water_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Cloud_Liquid_Water_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F14 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif14d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Rain_Rate_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Rain_Rate_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F14 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif14d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Rain_Rate_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Rain_Rate_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F14 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif14d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Water_Vapor_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Water_Vapor_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F14 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif14d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Water_Vapor_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Water_Vapor_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F14 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif14d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Wind_Speed_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Wind_Speed_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F14 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif14d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Wind_Speed_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F14_Wind_Speed_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F14 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif14d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Cloud_Liquid_Water_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Cloud_Liquid_Water_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F15 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif15d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Cloud_Liquid_Water_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Cloud_Liquid_Water_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F15 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif15d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Rain_Rate_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Rain_Rate_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F15 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif15d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Rain_Rate_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Rain_Rate_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F15 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif15d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Water_Vapor_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Water_Vapor_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F15 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif15d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Water_Vapor_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Water_Vapor_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F15 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif15d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Wind_Speed_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Wind_Speed_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F15 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif15d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Wind_Speed_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F15_Wind_Speed_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F15 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif15d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Cloud_Liquid_Water_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Cloud_Liquid_Water_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F16 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif16d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Cloud_Liquid_Water_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Cloud_Liquid_Water_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F16 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif16d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Rain_Rate_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Rain_Rate_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F16 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif16d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Rain_Rate_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Rain_Rate_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F16 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif16d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Water_Vapor_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Water_Vapor_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F16 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif16d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Water_Vapor_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Water_Vapor_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F16 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif16d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Wind_Speed_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Wind_Speed_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F16 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif16d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Wind_Speed_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F16_Wind_Speed_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F16 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif16d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Cloud_Liquid_Water_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Cloud_Liquid_Water_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F17 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif17d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Cloud_Liquid_Water_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Cloud_Liquid_Water_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F17 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif17d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Rain_Rate_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Rain_Rate_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F17 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif17d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Rain_Rate_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Rain_Rate_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F17 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif17d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Water_Vapor_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Water_Vapor_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F17 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif17d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Water_Vapor_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Water_Vapor_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F17 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif17d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Wind_Speed_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Wind_Speed_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F17 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif17d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Wind_Speed_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F17_Wind_Speed_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F17 / SSMIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif17d"
         }
     }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Cloud_Liquid_Water_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Cloud_Liquid_Water_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F8 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif08d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Cloud_Liquid_Water_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Cloud_Liquid_Water_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F8 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif08d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Rain_Rate_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Rain_Rate_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F8 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif08d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Rain_Rate_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Rain_Rate_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F8 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif08d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Water_Vapor_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Water_Vapor_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F8 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif08d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Water_Vapor_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Water_Vapor_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F8 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif08d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Wind_Speed_Over_Oceans_Ascending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Wind_Speed_Over_Oceans_Ascending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F8 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif08d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Wind_Speed_Over_Oceans_Descending.json
+++ b/common/config/wv.json/layers/ssmi/SSMI_DMSP_F8_Wind_Speed_Over_Oceans_Descending.json
@@ -6,6 +6,9 @@
             "subtitle": "DMSP-F8 / SSMI",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "ssmi"
+            ],
             "product":  "rssmif08d",
             "inactive": true
         }

--- a/common/config/wv.json/layers/trmm/LIS_High_Resolution_Full_Climatology_LIS_Flash_Rate_Climatology.json
+++ b/common/config/wv.json/layers/trmm/LIS_High_Resolution_Full_Climatology_LIS_Flash_Rate_Climatology.json
@@ -6,6 +6,9 @@
             "subtitle": "TRMM / LIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "trmm"
+            ],
             "product":  "lohrfc",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/trmm/LIS_High_Resolution_Full_Climatology_LIS_Raw_Flashes.json
+++ b/common/config/wv.json/layers/trmm/LIS_High_Resolution_Full_Climatology_LIS_Raw_Flashes.json
@@ -6,6 +6,9 @@
             "subtitle": "TRMM / LIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "trmm"
+            ],
             "product":  "lohrfc",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/trmm/LIS_High_Resolution_Full_Climatology_LIS_Scaled_Flashes.json
+++ b/common/config/wv.json/layers/trmm/LIS_High_Resolution_Full_Climatology_LIS_Scaled_Flashes.json
@@ -6,6 +6,9 @@
             "subtitle": "TRMM / LIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "trmm"
+            ],
             "product":  "lohrfc",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Daily_Climatology_LIS_Mean_Flash_Rate.json
+++ b/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Daily_Climatology_LIS_Mean_Flash_Rate.json
@@ -6,6 +6,9 @@
             "subtitle": "TRMM / LIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "trmm"
+            ],
             "product":  "lisvhrac",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Full_Climatology_LIS_Mean_Flash_Rate.json
+++ b/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Full_Climatology_LIS_Mean_Flash_Rate.json
@@ -6,6 +6,9 @@
             "subtitle": "TRMM / LIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "trmm"
+            ],
             "product":  "lisvhrfc",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Monthly_Climatology_LIS_Mean_Flash_Rate.json
+++ b/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Monthly_Climatology_LIS_Mean_Flash_Rate.json
@@ -6,6 +6,9 @@
             "subtitle": "TRMM / LIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "trmm"
+            ],
             "product":  "lisvhrmc",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Seasonal_Climatology_LIS_Mean_Flash_Rate.json
+++ b/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Seasonal_Climatology_LIS_Mean_Flash_Rate.json
@@ -6,6 +6,9 @@
             "subtitle": "TRMM / LIS",
             "tags":     "",
             "group":    "overlays",
+            "layergroup": [
+              "trmm"
+            ],
             "product":  "lisvhrsc",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/viirs/VIIRS_Black_Marble.json
+++ b/common/config/wv.json/layers/viirs/VIIRS_Black_Marble.json
@@ -5,6 +5,9 @@
             "title":    "Black Marble (Annual, 2012 & 2016)",
             "subtitle": "Suomi NPP / VIIRS via NASA Earth Observatory",
             "tags":     "night s-npp snpp night lights city urban",
+            "layergroup": [
+              "viirs"
+            ],
             "group":    "baselayers",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/viirs/VIIRS_CityLights_2012.json
+++ b/common/config/wv.json/layers/viirs/VIIRS_CityLights_2012.json
@@ -5,6 +5,9 @@
             "title":    "Earth at Night 2012",
             "subtitle": "Suomi NPP / VIIRS via NASA Earth Observatory",
             "tags":     "night lights city lights urban snpp s-npp",
+            "layergroup": [
+              "viirs"
+            ],
             "group":    "baselayers",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/viirs/VIIRS_Night_Lights.json
+++ b/common/config/wv.json/layers/viirs/VIIRS_Night_Lights.json
@@ -5,6 +5,9 @@
             "title":    "Black Marble - Nighttime Lights only (Annual, 2012 & 2016)",
             "subtitle": "Suomi NPP / VIIRS via NASA Earth Observatory",
             "tags":     "night s-npp snpp night lights city urban",
+            "layergroup": [
+              "viirs"
+            ],
             "group":    "overlays",
             "inactive": true,
             "wrapadjacentdays": true

--- a/common/config/wv.json/layers/viirs/VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1.json
+++ b/common/config/wv.json/layers/viirs/VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1.json
@@ -5,6 +5,9 @@
             "title":    "Corrected Reflectance (Bands M11-I2-I1)",
             "subtitle": "Suomi NPP / VIIRS",
             "tags":     "false color s-npp snpp 7-2-1",
+            "layergroup": [
+              "viirs"
+            ],
             "group":    "baselayers",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/viirs/VIIRS_SNPP_CorrectedReflectance_BandsM3-I3-M11.json
+++ b/common/config/wv.json/layers/viirs/VIIRS_SNPP_CorrectedReflectance_BandsM3-I3-M11.json
@@ -5,6 +5,9 @@
             "title":    "Corrected Reflectance (Bands M3-I3-M11)",
             "subtitle": "Suomi NPP / VIIRS",
             "tags":     "false color s-npp snpp 3-6-7",
+            "layergroup": [
+              "viirs"
+            ],
             "group":    "baselayers",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/viirs/VIIRS_SNPP_CorrectedReflectance_TrueColor.json
+++ b/common/config/wv.json/layers/viirs/VIIRS_SNPP_CorrectedReflectance_TrueColor.json
@@ -5,6 +5,9 @@
             "title":    "Corrected Reflectance (True Color)",
             "subtitle": "Suomi NPP / VIIRS",
             "tags":     "natural color cr s-npp snpp",
+            "layergroup": [
+              "viirs"
+            ],
             "group":    "baselayers",
             "wrapadjacentdays": true
         }

--- a/common/config/wv.json/layers/viirs/VIIRS_SNPP_DayNightBand_ENCC.json
+++ b/common/config/wv.json/layers/viirs/VIIRS_SNPP_DayNightBand_ENCC.json
@@ -5,6 +5,9 @@
             "title":    "Nighttime Imagery (Day/Night Band, Enhanced Near Constant Contrast)",
             "subtitle": "Suomi NPP / VIIRS",
             "tags":     "dnb night s-npp snpp night lights",
+            "layergroup": [
+              "viirs"
+            ],
             "group":    "overlays"
         }
     }

--- a/common/config/wv.json/layers/viirs/VIIRS_SNPP_Fires_375m_Day.json
+++ b/common/config/wv.json/layers/viirs/VIIRS_SNPP_Fires_375m_Day.json
@@ -5,6 +5,9 @@
             "title":    "Fires and Thermal Anomalies (Day, 375m)",
             "subtitle": "Suomi NPP / VIIRS",
             "tags":     "hotspot s-npp snpp",
+            "layergroup": [
+              "viirs"
+            ],
             "group":    "overlays",
             "format":   "image/png",
             "period":   "daily",

--- a/common/config/wv.json/layers/viirs/VIIRS_SNPP_Fires_375m_Night.json
+++ b/common/config/wv.json/layers/viirs/VIIRS_SNPP_Fires_375m_Night.json
@@ -5,6 +5,9 @@
             "title":    "Fires and Thermal Anomalies (Night, 375m)",
             "subtitle": "Suomi NPP / VIIRS",
             "tags":     "hotspot s-npp snpp",
+            "layergroup": [
+              "viirs"
+            ],
             "group":    "overlays",
             "format":   "image/png",
             "period":   "daily",


### PR DESCRIPTION
- Added `layergroup` parameter to each layer file. This references the folder (group i.e. airs, modis, reference_orbits), to provide an easy way to filter all layers within a specific group. This is used to now filter orbit tracks in some situations.
- Added `daynight` and `track` to orbit layers. This is now used to better output the titles within the Measurement / Sources add modal view.
- Added `description` parameter to orbit layers and added single orbit descriptions. This is the first of the layers to start using per-layer description for output in the info windows and search descriptions.