### PR TITLE
Add https protocol to sources URLS

### DIFF
--- a/release/config/wv.json/sources.json
+++ b/release/config/wv.json/sources.json
@@ -1,16 +1,16 @@
 {
     "sources": {
         "GIBS:arctic": {
-            "url": "//gibs-{a-c}.earthdata.nasa.gov/wmts/epsg3413/best/wmts.cgi"
+            "url": "https://gibs-{a-c}.earthdata.nasa.gov/wmts/epsg3413/best/wmts.cgi"
         },
         "GIBS:antarctic": {
-            "url": "//gibs-{a-c}.earthdata.nasa.gov/wmts/epsg3031/best/wmts.cgi"
+            "url": "https://gibs-{a-c}.earthdata.nasa.gov/wmts/epsg3031/best/wmts.cgi"
         },
         "GIBS:geographic": {
-            "url": "//gibs-{a-c}.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi"
+            "url": "https://gibs-{a-c}.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi"
         },
         "GIBS:wms": {
-            "url": "//gibs-{a-c}.earthdata.nasa.gov/wms/wms.php"
+            "url": "https://gibs-{a-c}.earthdata.nasa.gov/wms/wms.php"
         },
         "SEDAC:wms": {
             "url": "http://sedac.ciesin.columbia.edu/geoserver/wms"


### PR DESCRIPTION
Always request the https version of tile sources.

This fixes [a bug](https://bugs.earthdata.nasa.gov/browse/GIBS-2199) that was blocking https://github.com/nasa-gibs/worldview/issues/454