### PR TITLE
Remove link to dependencies list

### DIFF
--- a/common/brand/pages/about.html
+++ b/common/brand/pages/about.html
@@ -140,6 +140,10 @@
             The imagery ingest and serving system (GIBS) is built by
             NASA/JPL and operated by NASA/GSFC.
           </li>
+          <li>
+             @NAME@ is built by the NASA/GSFC <a href='https://earthdata.nasa.gov/about/esdis-project' target='_blank'>Earth Science Data and Information System (ESDIS) Project</a>.
+             We are grateful for the many third-party projects we depend on which are listed in <a href="https://github.com/nasa-gibs/worldview/blob/master/package.json">our package.json manifest</a> under "dependencies".
+          </li>
         </ul>
       </p>
 

--- a/common/brand/pages/about.html
+++ b/common/brand/pages/about.html
@@ -140,13 +140,6 @@
             The imagery ingest and serving system (GIBS) is built by
             NASA/JPL and operated by NASA/GSFC.
           </li>
-          <li>
-            @NAME@ is built by the NASA/GSFC Earth Science Data and
-            Information System
-            (<a href='https://earthdata.nasa.gov/about/esdis-project' target='_blank'>ESDIS</a>)
-            Project and is grateful for the use of many
-            <a href='https://worldview.earthdata.nasa.gov/pages/worldview-opensourcelibs.html' target='_blank'>open source projects</a>.
-          </li>
         </ul>
       </p>
 


### PR DESCRIPTION
The dependencies list is now in package.json after https://github.com/nasa-gibs/worldview/pull/503