### PR TITLE
Removed inactive tag and updated text

### DIFF
--- a/common/config/metadata/calipso/CALIPSO_Wide_Field_Camera_Radiance_v3-01.md
+++ b/common/config/metadata/calipso/CALIPSO_Wide_Field_Camera_Radiance_v3-01.md
@@ -1,2 +1,2 @@
 ### Radiance (Daily, V3-01)
-Temporal coverage: 13 June 2006 - 31 October 2011
+Temporal coverage: 13 June 2006 - 1 November 2011

--- a/common/config/wv.json/layers/calipso/CALIPSO_Wide_Field_Camera_Radiance_v3-02.json
+++ b/common/config/wv.json/layers/calipso/CALIPSO_Wide_Field_Camera_Radiance_v3-02.json
@@ -9,8 +9,7 @@
             "layergroup": [
               "calipso"
             ],
-            "product":  "",
-            "inactive": true
+            "product":  ""
         }
     }
 }


### PR DESCRIPTION
Closes nasa-gibs/worldview#751.
Removed inactive tag from CALIPSO Radiance (Daily, V3-02); updated end
date for CALIPSO Radiance (Daily, V3-01)