### PR TITLE
Changed orbit track names

### DIFF
--- a/common/config/metadata/reference/orbits/Aqua.md
+++ b/common/config/metadata/reference/orbits/Aqua.md
@@ -1,9 +1,9 @@
 ### Orbital Track (Ascending/Day) Aqua
-Orbital Track (Ascending/Day) Aqua layer is the path of the Aqua satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
+The Aqua Orbital Track (Ascending/Day) layer is the path of the Aqua satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.
 
 ### Orbital Track (Descending/Night) Aqua
-Orbital Track (Descending/Day) Aqua layer is the path of the Aqua satellite on its ascending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
+The Aqua Orbital Track (Descending/Day) layer is the path of the Aqua satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Aqua_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Aqua_Orbit_Asc.md
@@ -1,4 +1,4 @@
 ### Orbital Track (Ascending/Day) Aqua
-Orbital Track (Ascending/Day) Aqua layer is the path of the Aqua satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
+The Aqua Orbital Track (Ascending/Day) layer is the path of the Aqua satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Aqua_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Aqua_Orbit_Dsc.md
@@ -1,4 +1,4 @@
 ### Orbital Track (Descending/Night) Aqua
-Orbital Track (Descending/Day) Aqua layer is the path of the Aqua satellite on its ascending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
+The Aqua Orbital Track (Descending/Day) layer is the path of the Aqua satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Aura.md
+++ b/common/config/metadata/reference/orbits/Aura.md
@@ -1,9 +1,9 @@
 ### Orbital Track (Ascending/Day) Aura
-Orbital Track (Ascending/Day) Aura layer is the path of the Aura satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
+The Aura Orbital Track (Ascending/Day) layer is the path of the Aura satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.
 
 ### Orbital Track (Descending/Night) Aura
-Orbital Track (Descending/Night) Aura layer is the path of the Aura satellite on its ascending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
+The Aura Orbital Track (Descending/Night) layer is the path of the Aura satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Aura_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Aura_Orbit_Asc.md
@@ -1,4 +1,4 @@
 ### Orbital Track (Ascending/Day) Aura
-Orbital Track (Ascending/Day) Aura layer is the path of the Aura satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
+The Aura Orbital Track (Ascending/Day) layer is the path of the Aura satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Aura_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Aura_Orbit_Dsc.md
@@ -1,4 +1,4 @@
 ### Orbital Track (Descending/Night) Aura
-Orbital Track (Descending/Night) Aura layer is the path of the Aura satellite on its ascending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
+The Aura Orbital Track (Descending/Night) layer is the path of the Aura satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/CALIPSO.md
+++ b/common/config/metadata/reference/orbits/CALIPSO.md
@@ -1,9 +1,9 @@
 ### Orbital Track (Ascending/Day) CALIPSO
-Orbital Track (Ascending/Day)  CALIPSO layer is the path of the  Cloud-Aerosol Lidar and Infrared Pathfinder Satellite Observation (CALIPSO) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
+The CALIPSO Orbital Track (Ascending/Day) layer is the path of the  Cloud-Aerosol Lidar and Infrared Pathfinder Satellite Observation (CALIPSO) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.
 
 ### Orbital Track (Descending/Night) CALIPSO
-Orbital Track (Descending/Night) CALIPSO layer is the path of the  Cloud-Aerosol Lidar and Infrared Pathfinder Satellite Observation  (CALIPSO) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
+The CALIPSO Orbital Track (Descending/Night) layer is the path of the  Cloud-Aerosol Lidar and Infrared Pathfinder Satellite Observation (CALIPSO) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Calipso_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Calipso_Orbit_Asc.md
@@ -1,4 +1,4 @@
 ### Orbital Track (Ascending/Day) CALIPSO
-Orbital Track (Ascending/Day)  CALIPSO layer is the path of the  Cloud-Aerosol Lidar and Infrared Pathfinder Satellite Observation (CALIPSO) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
+The CALIPSO Orbital Track (Ascending/Day) layer is the path of the  Cloud-Aerosol Lidar and Infrared Pathfinder Satellite Observation (CALIPSO) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Calipso_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Calipso_Orbit_Dsc.md
@@ -1,4 +1,4 @@
 ### Orbital Track (Descending/Night) CALIPSO
-Orbital Track (Descending/Night) CALIPSO layer is the path of the  Cloud-Aerosol Lidar and Infrared Pathfinder Satellite Observation  (CALIPSO) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
+The CALIPSO Orbital Track (Descending/Night) layer is the path of the  Cloud-Aerosol Lidar and Infrared Pathfinder Satellite Observation (CALIPSO) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/GCOM-W1.md
+++ b/common/config/metadata/reference/orbits/GCOM-W1.md
@@ -1,9 +1,9 @@
 ### Orbital Track (Ascending/Day) GCOM-W1
-Orbital Track (Ascending/Day) GCOM-W1 layer is the path of the Global Change Observation Mission - Water 1 “Shizuku” (GCOM-W1) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
+The GCOM-W1 Orbital Track (Ascending/Day) layer is the path of the Global Change Observation Mission - Water 1 “Shizuku” (GCOM-W1) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.
 
 ### Orbital Track (Descending/Night) GCOM-W1
-Orbital Track (Descending/Night) GCOM-W1 layer is the path of the Global Change Observation Mission - Water 1 “Shizuku” (GCOM-W1) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
+The GCOM-W1 Orbital Track (Descending/Night) layer is the path of the Global Change Observation Mission - Water 1 “Shizuku” (GCOM-W1) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/GCOM_W1_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/GCOM_W1_Orbit_Asc.md
@@ -1,4 +1,4 @@
 ### Orbital Track (Ascending/Day) GCOM-W1
-Orbital Track (Ascending/Day) GCOM-W1 layer is the path of the Global Change Observation Mission - Water 1 “Shizuku” (GCOM-W1) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
+The GCOM-W1 Orbital Track (Ascending/Day) layer is the path of the Global Change Observation Mission - Water 1 “Shizuku” (GCOM-W1) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/GCOM_W1_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/GCOM_W1_Orbit_Dsc.md
@@ -1,4 +1,4 @@
 ### Orbital Track (Descending/Night) GCOM-W1
-Orbital Track (Descending/Night) GCOM-W1 layer is the path of the Global Change Observation Mission - Water 1 “Shizuku” (GCOM-W1) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
+The GCOM-W1 Orbital Track (Descending/Night) layer is the path of the Global Change Observation Mission - Water 1 “Shizuku” (GCOM-W1) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/GPM.md
+++ b/common/config/metadata/reference/orbits/GPM.md
@@ -1,9 +1,9 @@
-### Orbital Track (Ascending/Day) GPM
-Orbital Track (Ascending/Day) GPM layer is the path of the Global Precipitation Measurement (GPM) core observatory on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC).
+### Orbital Track (Ascending) GPM
+The GPM Orbital Track (Ascending) layer is the path of the Global Precipitation Measurement (GPM) core observatory on its ascending orbit. Orbit Track times are shown in Coordinated Universal Time (UTC).
 
 Orbital Track information from <https://www.space-track.org/>.
 
-### Orbital Track (Descending/Day) GPM
-Orbital Track (Descending/Day) GPM layer is the path of the Global Precipitation Measurement (GPM) core observatory on its descending/day orbit. Orbit Track times are shown in Coordinated Universal Time (UTC).
+### Orbital Track (Descending) GPM
+The GPM Orbital Track (Descending) layer is the path of the Global Precipitation Measurement (GPM) core observatory on its descending orbit. Orbit Track times are shown in Coordinated Universal Time (UTC).
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/GPM_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/GPM_Orbit_Asc.md
@@ -1,4 +1,4 @@
-### Orbital Track (Ascending/Day) GPM
-Orbital Track (Ascending/Day) GPM layer is the path of the Global Precipitation Measurement (GPM) core observatory on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC).
+### Orbital Track (Ascending) GPM
+The GPM Orbital Track (Ascending/Day) layer is the path of the Global Precipitation Measurement (GPM) core observatory on its ascending orbit. Orbit Track times are shown in Coordinated Universal Time (UTC).
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/GPM_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/GPM_Orbit_Dsc.md
@@ -1,4 +1,4 @@
 ### Orbital Track (Descending/Day) GPM
-Orbital Track (Descending/Day) GPM layer is the path of the Global Precipitation Measurement (GPM) core observatory on its descending/day orbit. Orbit Track times are shown in Coordinated Universal Time (UTC).
+The GPM Orbital Track (Descending) layer is the path of the Global Precipitation Measurement (GPM) core observatory on its descending orbit. Orbit Track times are shown in Coordinated Universal Time (UTC).
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Landsat_8.md
+++ b/common/config/metadata/reference/orbits/Landsat_8.md
@@ -1,0 +1,9 @@
+### Orbital Track (Ascending/Day) Landsat 8
+The Landsat 8 Orbital Track (Ascending/Day) layer is the path of the Landsat 8 satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Landsat 8 is on a sun-synchronous orbit at an altitude of 705 km (438 mi) with an equatorial crossing time of 10:00 a.m. +/- 15 minutes (UTC).
+
+Orbital Track information from <https://www.space-track.org/>.
+
+### Orbital Track (Descending/Night) Landsat 8
+The Landsat 8 Orbital Track (Descending/Night) layer is the path of the Landsat 8 satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Landsat 8 is on a sun-synchronous orbit at an altitude of 705 km (438 mi) with an equatorial crossing time of 10:00 a.m. +/- 15 minutes (UTC).
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Landsat_8_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Landsat_8_Orbit_Asc.md
@@ -1,0 +1,4 @@
+### Orbital Track (Ascending/Day) Landsat 8
+The Landsat 8 Orbital Track (Ascending/Day) layer is the path of the Landsat 8 satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Landsat 8 is on a sun-synchronous orbit at an altitude of 705 km (438 mi) with an equatorial crossing time of 10:00 a.m. +/- 15 minutes (UTC).
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Landsat_8_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Landsat_8_Orbit_Dsc.md
@@ -1,0 +1,4 @@
+### Orbital Track (Descending/Night) Landsat 8
+The Landsat 8 Orbital Track (Descending/Night) layer is the path of the Landsat 8 satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Landsat 8 is on a sun-synchronous orbit at an altitude of 705 km (438 mi) with an equatorial crossing time of 10:00 a.m. +/- 15 minutes (UTC).
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/SMAP.md
+++ b/common/config/metadata/reference/orbits/SMAP.md
@@ -1,0 +1,9 @@
+### Orbital Track (Descending/Day) Suomi NPP
+The SMAP Orbital Track (Descending/Day) layer is the path of the Soil Moisture Active Passive satellite on its descending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). SMAP is at a 685-km altitude, near-polar, sun-synchronous 6am/6pm, 8-day exact repeat, frozen orbit.
+
+Orbital Track information from <https://www.space-track.org/>.
+
+### Orbital Track (Ascending/Night) SMAP
+The SMAP Orbital Track (Ascending/Night) layer is the path of the Soil Moisture Active Passive satellite on its ascending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). SMAP is at a 685-km altitude, near-polar, sun-synchronous 6am/6pm, 8-day exact repeat, frozen orbit.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/SMAP_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/SMAP_Orbit_Asc.md
@@ -1,0 +1,4 @@
+### Orbital Track (Ascending/Night) SMAP
+The SMAP Orbital Track (Ascending/Night) layer is the path of the Soil Moisture Active Passive satellite on its ascending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). SMAP is at a 685-km altitude, near-polar, sun-synchronous 6am/6pm, 8-day exact repeat, frozen orbit.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/SMAP_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/SMAP_Orbit_Dsc.md
@@ -1,0 +1,4 @@
+### Orbital Track (Descending/Day) Suomi NPP
+The SMAP Orbital Track (Descending/Day) layer is the path of the Soil Moisture Active Passive satellite on its descending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). SMAP is at a 685-km altitude, near-polar, sun-synchronous 6am/6pm, 8-day exact repeat, frozen orbit.
+
+Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/SNPP.md
+++ b/common/config/metadata/reference/orbits/SNPP.md
@@ -1,9 +1,9 @@
 ### Orbital Track (Ascending/Day) Suomi NPP
-Orbital Track (Ascending/Day) Suomi NPP layer is the path of the Suomi National Polar-orbiting Partnership (NPP) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is approximately 13:30.
+The Suomi NPP Orbital Track (Ascending/Day) layer is the path of the Suomi National Polar-orbiting Partnership (NPP) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is approximately 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.
 
 ### Orbital Track (Descending/Night) Suomi NPP
-Orbital Track (Descending/Night) Suomi NPP layer is the path of the Suomi National Polar-orbiting Partnership (NPP) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is approximately 01:30.
+The Suomi NPP Orbital Track (Descending/Night) layer is the path of the Suomi National Polar-orbiting Partnership (NPP) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is approximately 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Suomi_NPP_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Suomi_NPP_Orbit_Asc.md
@@ -1,4 +1,4 @@
 ### Orbital Track (Ascending/Day) Suomi NPP
-Orbital Track (Ascending/Day) Suomi NPP layer is the path of the Suomi National Polar-orbiting Partnership (NPP) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is approximately 13:30.
+The Suomi NPP Orbital Track (Ascending/Day) layer is the path of the Suomi National Polar-orbiting Partnership (NPP) satellite on its ascending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is approximately 13:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Suomi_NPP_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Suomi_NPP_Orbit_Dsc.md
@@ -1,4 +1,4 @@
 ### Orbital Track (Descending/Night) Suomi NPP
-Orbital Track (Descending/Night) Suomi NPP layer is the path of the Suomi National Polar-orbiting Partnership (NPP) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is approximately 01:30.
+The Suomi NPP Orbital Track (Descending/Night) layer is the path of the Suomi National Polar-orbiting Partnership (NPP) satellite on its descending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is approximately 01:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Terra.md
+++ b/common/config/metadata/reference/orbits/Terra.md
@@ -1,9 +1,9 @@
 ### Orbital Track (Ascending/Night) Terra
-Orbital Track (Ascending/Night) Terra layer is the path of the Terra satellite on its ascending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 22:30.
+The Terra Orbital Track (Ascending/Night) layer is the path of the Terra satellite on its ascending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 22:30.
 
 Orbital Track information from <https://www.space-track.org/>.
 
 ### Orbital Track (Descending/Day) Terra
-Orbital Track (Descending/Day) Terra layer is the path of the Terra satellite on its descending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 10:30.
+The Terra Orbital Track (Descending/Day) layer is the path of the Terra satellite on its descending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 10:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Terra_Orbit_Asc.md
+++ b/common/config/metadata/reference/orbits/Terra_Orbit_Asc.md
@@ -1,4 +1,4 @@
 ### Orbital Track (Ascending/Night) Terra
-Orbital Track (Ascending/Night) Terra layer is the path of the Terra satellite on its ascending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 22:30.
+The Terra Orbital Track (Ascending/Night) layer is the path of the Terra satellite on its ascending/night-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 22:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/metadata/reference/orbits/Terra_Orbit_Dsc.md
+++ b/common/config/metadata/reference/orbits/Terra_Orbit_Dsc.md
@@ -1,4 +1,4 @@
 ### Orbital Track (Descending/Day) Terra
-Orbital Track (Descending/Day) Terra layer is the path of the Terra satellite on its descending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 10:30.
+The Terra Orbital Track (Descending/Day) layer is the path of the Terra satellite on its descending/day-time orbit. Orbit Track times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 10:30.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/common/config/wv.json/layers/reference/orbits/Aqua_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/Aqua_Orbit_Asc.json
@@ -2,7 +2,7 @@
     "layers": {
         "Aqua_Orbit_Asc": {
             "id":       "Aqua_Orbit_Asc",
-            "title":    "Orbital Track (Ascending/Day)",
+            "title":    "Aqua Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / Aqua",
             "description": "reference/orbits/Aqua_Orbit_Asc",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/Aqua_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/Aqua_Orbit_Dsc.json
@@ -2,7 +2,7 @@
     "layers": {
         "Aqua_Orbit_Dsc": {
             "id":       "Aqua_Orbit_Dsc",
-            "title":    "Orbital Track (Descending/Night)",
+            "title":    "Aqua Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / Aqua",
             "description": "reference/orbits/Aqua_Orbit_Dsc",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/Aura_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/Aura_Orbit_Asc.json
@@ -2,7 +2,7 @@
     "layers": {
         "Aura_Orbit_Asc": {
             "id":       "Aura_Orbit_Asc",
-            "title":    "Orbital Track (Ascending/Day)",
+            "title":    "Aura Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / Aura",
             "description": "reference/orbits/Aura_Orbit_Asc",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/Aura_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/Aura_Orbit_Dsc.json
@@ -2,7 +2,7 @@
     "layers": {
         "Aura_Orbit_Dsc": {
             "id":       "Aura_Orbit_Dsc",
-            "title":    "Orbital Track (Descending/Night)",
+            "title":    "Aura Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / Aura",
             "description": "reference/orbits/Aura_Orbit_Dsc",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/Calipso_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/Calipso_Orbit_Asc.json
@@ -2,7 +2,7 @@
     "layers": {
         "Calipso_Orbit_Asc": {
             "id":       "Calipso_Orbit_Asc",
-            "title":    "Orbital Track (Ascending/Day)",
+            "title":    "CALIPSO Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / CALIPSO",
             "description": "reference/orbits/Calipso_Orbit_Asc",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/Calipso_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/Calipso_Orbit_Dsc.json
@@ -2,7 +2,7 @@
     "layers": {
         "Calipso_Orbit_Dsc": {
             "id":       "Calipso_Orbit_Dsc",
-            "title":    "Orbital Track (Descending/Night)",
+            "title":    "CALIPSO Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / CALIPSO",
             "description": "reference/orbits/Calipso_Orbit_Dsc",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/GCOM_W1_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/GCOM_W1_Orbit_Asc.json
@@ -2,7 +2,7 @@
     "layers": {
         "GCOM_W1_Orbit_Asc": {
             "id":       "GCOM_W1_Orbit_Asc",
-            "title":    "Orbital Track (Ascending/Day)",
+            "title":    "GCOM-W1 Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / GCOM-W1",
             "description": "reference/orbits/GCOM_W1_Orbit_Asc",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/GCOM_W1_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/GCOM_W1_Orbit_Dsc.json
@@ -2,7 +2,7 @@
     "layers": {
         "GCOM_W1_Orbit_Dsc": {
             "id":       "GCOM_W1_Orbit_Dsc",
-            "title":    "Orbital Track (Descending/Night)",
+            "title":    "GCOM_W1 Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / GCOM-W1",
             "description": "reference/orbits/GCOM_W1_Orbit_Dsc",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/GOSAT_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/GOSAT_Orbit_Asc.json
@@ -2,7 +2,7 @@
     "layers": {
         "GOSAT_Orbit_Asc": {
             "id":       "GOSAT_Orbit_Asc",
-            "title":    "Orbital Track (Ascending/Day)",
+            "title":    "GOSAT Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / GOSAT",
             "description": "",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/GOSAT_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/GOSAT_Orbit_Dsc.json
@@ -2,7 +2,7 @@
     "layers": {
         "GOSAT_Orbit_Dsc": {
             "id":       "GOSAT_Orbit_Dsc",
-            "title":    "Orbital Track (Descending/Night)",
+            "title":    "GOSAT Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / GOSAT",
             "description": "",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/GPM_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/GPM_Orbit_Asc.json
@@ -2,7 +2,7 @@
     "layers": {
         "GPM_Orbit_Asc": {
             "id":       "GPM_Orbit_Asc",
-            "title":    "Orbital Track (Ascending/Day)",
+            "title":    "GPM Orbital Track (Ascending)",
             "subtitle": "Space-Track.org / GPM",
             "description": "reference/orbits/GPM_Orbit_Asc",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/GPM_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/GPM_Orbit_Dsc.json
@@ -2,7 +2,7 @@
     "layers": {
         "GPM_Orbit_Dsc": {
             "id":       "GPM_Orbit_Dsc",
-            "title":    "Orbital Track (Descending/Day)",
+            "title":    "GPM Orbital Track (Descending)",
             "subtitle": "Space-Track.org / GPM",
             "description": "reference/orbits/GPM_Orbit_Dsc",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/ISS_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/ISS_Orbit_Asc.json
@@ -2,7 +2,7 @@
     "layers": {
         "ISS_Orbit_Asc": {
             "id":       "ISS_Orbit_Asc",
-            "title":    "Orbital Track (Ascending/Day)",
+            "title":    "ISS Orbital Track (Ascending)",
             "subtitle": "Space-Track.org / Int'l Space Station",
             "description": "",
             "tags":     "iss international",

--- a/common/config/wv.json/layers/reference/orbits/ISS_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/ISS_Orbit_Dsc.json
@@ -2,7 +2,7 @@
     "layers": {
         "ISS_Orbit_Dsc": {
             "id":       "ISS_Orbit_Dsc",
-            "title":    "Orbital Track (Descending/Night)",
+            "title":    "ISS Orbital Track (Descending)",
             "subtitle": "Space-Track.org / Int'l Space Station",
             "description": "",
             "tags":     "iss international",

--- a/common/config/wv.json/layers/reference/orbits/Landsat_8_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/Landsat_8_Orbit_Asc.json
@@ -2,9 +2,9 @@
     "layers": {
         "Landsat_8_Orbit_Asc": {
             "id":       "Landsat_8_Orbit_Asc",
-            "title":    "Orbital Track (Ascending/Day)",
+            "title":    "Landsat 8 Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / Landsat 8",
-            "description": "",
+            "description": "reference/orbits/Landsat_8_Orbit_Asc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",

--- a/common/config/wv.json/layers/reference/orbits/Landsat_8_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/Landsat_8_Orbit_Dsc.json
@@ -2,9 +2,9 @@
     "layers": {
         "Landsat_8_Orbit_Dsc": {
             "id":       "Landsat_8_Orbit_Dsc",
-            "title":    "Orbital Track (Descending/Night)",
+            "title":    "Landsat 8 Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / Landsat 8",
-            "description": "",
+            "description": "reference/orbits/Landsat_8_Orbit_Dsc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",

--- a/common/config/wv.json/layers/reference/orbits/OCO_2_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/OCO_2_Orbit_Asc.json
@@ -2,7 +2,7 @@
     "layers": {
         "OCO_2_Orbit_Asc": {
             "id":       "OCO_2_Orbit_Asc",
-            "title":    "Orbital Track (Ascending/Day)",
+            "title":    "OCO-2 Orbital Track (Ascending/Day)",
             "subtitle": "Space-Track.org / OCO-2",
             "description": "",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/OCO_2_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/OCO_2_Orbit_Dsc.json
@@ -2,7 +2,7 @@
     "layers": {
         "OCO_2_Orbit_Dsc": {
             "id":       "OCO_2_Orbit_Dsc",
-            "title":    "Orbital Track (Descending/Night)",
+            "title":    "OCO-2 Orbital Track (Descending/Night)",
             "subtitle": "Space-Track.org / OCO-2",
             "description": "",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/SMAP_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/SMAP_Orbit_Asc.json
@@ -2,9 +2,9 @@
     "layers": {
         "SMAP_Orbit_Asc": {
             "id":       "SMAP_Orbit_Asc",
-            "title":    "Orbital Track (Ascending/Night)",
+            "title":    "SMAP Orbital Track (Ascending/Night)",
             "subtitle": "Space-Track.org / SMAP",
-            "description": "",
+            "description": "reference/orbits/SMAP_Orbit_Asc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",

--- a/common/config/wv.json/layers/reference/orbits/SMAP_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/SMAP_Orbit_Dsc.json
@@ -2,9 +2,9 @@
     "layers": {
         "SMAP_Orbit_Dsc": {
             "id":       "SMAP_Orbit_Dsc",
-            "title":    "Orbital Track (Descending/Day)",
+            "title":    "SMAP Orbital Track (Descending/Day)",
             "subtitle": "Space-Track.org / SMAP",
-            "description": "",
+            "description": "reference/orbits/SMAP_Orbit_Dsc",
             "group":    "overlays",
             "format":   "image/png",
             "type":     "wms",

--- a/common/config/wv.json/layers/reference/orbits/Suomi_NPP_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/Suomi_NPP_Orbit_Asc.json
@@ -2,8 +2,8 @@
     "layers": {
         "Suomi_NPP_Orbit_Asc": {
             "id":       "Suomi_NPP_Orbit_Asc",
-            "title":    "Orbital Track (Ascending/Day)",
-            "subtitle": "Space-Track.org / Suomi NPP",
+            "title":    "Suomi NPP Orbital Track (Ascending/Day)",
+            "subtitle": "Space-Track.org / Suomi-NPP",
             "description": "reference/orbits/Suomi_NPP_Orbit_Asc",
             "group":    "overlays",
             "tags":     "snpp s-npp",

--- a/common/config/wv.json/layers/reference/orbits/Suomi_NPP_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/Suomi_NPP_Orbit_Dsc.json
@@ -2,8 +2,8 @@
     "layers": {
         "Suomi_NPP_Orbit_Dsc": {
             "id":       "Suomi_NPP_Orbit_Dsc",
-            "title":    "Orbital Track (Descending/Night)",
-            "subtitle": "Space-Track.org / Suomi NPP",
+            "title":    "Suomi NPP Orbital Track (Descending/Night)",
+            "subtitle": "Space-Track.org / Suomi NPP ",
             "description": "reference/orbits/Suomi_NPP_Orbit_Dsc",
             "group":    "overlays",
             "tags":     "snpp s-npp",

--- a/common/config/wv.json/layers/reference/orbits/Terra_Orbit_Asc.json
+++ b/common/config/wv.json/layers/reference/orbits/Terra_Orbit_Asc.json
@@ -2,7 +2,7 @@
     "layers": {
         "Terra_Orbit_Asc": {
             "id":       "Terra_Orbit_Asc",
-            "title":    "Orbital Track (Ascending/Night)",
+            "title":    "Terra Orbital Track (Ascending/Night)",
             "subtitle": "Space-Track.org / Terra",
             "description": "reference/orbits/Terra_Orbit_Asc",
             "group":    "overlays",

--- a/common/config/wv.json/layers/reference/orbits/Terra_Orbit_Dsc.json
+++ b/common/config/wv.json/layers/reference/orbits/Terra_Orbit_Dsc.json
@@ -2,7 +2,7 @@
     "layers": {
         "Terra_Orbit_Dsc": {
             "id":       "Terra_Orbit_Dsc",
-            "title":    "Orbital Track (Descending/Day)",
+            "title":    "Terra Orbital Track (Descending/Day)",
             "subtitle": "Space-Track.org / Terra",
             "description": "reference/orbits/Terra_Orbit_Dsc",
             "group":    "overlays",

--- a/common/config/wv.json/measurements/Orbital Track.json
+++ b/common/config/wv.json/measurements/Orbital Track.json
@@ -78,7 +78,7 @@
                 "Space-Track.org / SMAP": {
                     "id": "space-track-org-smap",
                     "title": "Space-Track.org / SMAP",
-                    "description": "",
+                    "description": "reference/orbits/SMAP",
                     "image": "",
                     "settings": [
                         "SMAP_Orbit_Asc",
@@ -88,7 +88,7 @@
                 "Space-Track.org / Landsat 8": {
                     "id": "space-track-org-landsat-8",
                     "title": "Space-Track.org / Landsat 8",
-                    "description": "",
+                    "description": "reference/orbits/Landsat_8",
                     "image": "",
                     "settings": [
                         "Landsat_8_Orbit_Asc",


### PR DESCRIPTION
Closes nasa-gibs/worldview#185
Changed orbit track names to include satellite in title and added SMAP
and Landsat 8 orbit track layer descriptions