### PR TITLE
Always show login banner for AIRS SO2 Prata

### DIFF
--- a/common/config/wv.json/products/airs/AIRIBRAD_DAY.json
+++ b/common/config/wv.json/products/airs/AIRIBRAD_DAY.json
@@ -13,9 +13,8 @@
                 "value": "\\(NRT\\)"
             },
             "urs": {
-                "by": "regex",
-                "field": "dataset_id",
-                "value": "\\(NRT\\)"
+                "by": "constant",
+                "value": "true"
             }
         }
     }

--- a/common/config/wv.json/products/airs/AIRIBRAD_NIGHT.json
+++ b/common/config/wv.json/products/airs/AIRIBRAD_NIGHT.json
@@ -13,9 +13,8 @@
                 "value": "\\(NRT\\)"
             },
             "urs": {
-                "by": "regex",
-                "field": "dataset_id",
-                "value": "\\(NRT\\)"
+                "by": "constant",
+                "value": "true"
             }
         }
     }


### PR DESCRIPTION
## Description

Fixes nasa-gibs/worldview#814.

Always show login banner for AIRS SO2 Prata layers.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
