### PR TITLE
Add polar projections category layers for natural events support

### DIFF
--- a/common/config/wv.json/naturalEvents.json
+++ b/common/config/wv.json/naturalEvents.json
@@ -172,6 +172,8 @@
           "antarctic": {
             "Sea and Lake Ice": [
                 ["Reference_Features", true],
+                ["Reference_Labels", true],
+                ["Coastlines", true],
                 ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false],
                 ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
                 ["MODIS_Terra_CorrectedReflectance_TrueColor", true],
@@ -185,12 +187,16 @@
             ],
             "Severe Storms": [
                 ["Reference_Features", true],
+                ["Reference_Labels", true],
+                ["Coastlines", true],
                 ["VIIRS_SNPP_CorrectedReflectance_TrueColor", true],
                 ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
                 ["MODIS_Terra_CorrectedReflectance_TrueColor", false]
             ],
             "Snow": [
                 ["Reference_Features", true],
+                ["Reference_Labels", true],
+                ["Coastlines", true],
                 ["VIIRS_SNPP_CorrectedReflectance_TrueColor", true],
                 ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
                 ["MODIS_Terra_CorrectedReflectance_TrueColor", false],
@@ -199,6 +205,8 @@
             ],
             "Default": [
                 ["Reference_Features", true],
+                ["Reference_Labels", true],
+                ["Coastlines", true],
                 ["MODIS_Terra_CorrectedReflectance_TrueColor", true],
                 ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
                 ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false]

--- a/common/config/wv.json/naturalEvents.json
+++ b/common/config/wv.json/naturalEvents.json
@@ -1,6 +1,86 @@
 {
     "naturalEvents": {
         "layers": {
+          "arctic": {
+            "Wildfires": [
+                ["MODIS_Terra_CorrectedReflectance_TrueColor", true],
+                ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
+                ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Fires_Terra", true],
+                ["MODIS_Fires_Aqua", false],
+                ["Reference_Features", true],
+                ["Reference_Labels", true],
+                ["VIIRS_SNPP_Fires_375m_Day", false],
+                ["VIIRS_SNPP_Fires_375m_Night", false]
+            ],
+            "Temperature Extremes": [
+                ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Terra_CorrectedReflectance_TrueColor", true],
+                ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false],
+                ["Reference_Features", true],
+                ["Reference_Labels", true]
+            ],
+            "Sea and Lake Ice": [
+                ["Reference_Features", true],
+                ["Reference_Labels", true],
+                ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Terra_CorrectedReflectance_TrueColor", true],
+                ["VIIRS_SNPP_DayNightBand_ENCC", false],
+                ["MODIS_Terra_Brightness_Temp_Band31_Day", false],
+                ["MODIS_Terra_Brightness_Temp_Band31_Night", false],
+                ["MODIS_Aqua_Brightness_Temp_Band31_Day", false],
+                ["MODIS_Aqua_Brightness_Temp_Band31_Night", false],
+                ["MODIS_Aqua_Sea_Ice", false],
+                ["MODIS_Terra_Sea_Ice", false]
+            ],
+            "Water Color": [
+                ["Reference_Features", true],
+                ["Reference_Labels", true],
+                ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Terra_CorrectedReflectance_TrueColor", true]
+            ],
+            "Severe Storms": [
+                ["Reference_Features", true],
+                ["Reference_Labels", true],
+                ["VIIRS_SNPP_CorrectedReflectance_TrueColor", true],
+                ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Terra_CorrectedReflectance_TrueColor", false]
+            ],
+            "Snow": [
+                ["Reference_Features", true],
+                ["Reference_Labels", true],
+                ["VIIRS_SNPP_CorrectedReflectance_TrueColor", true],
+                ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Terra_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Aqua_NDSI_Snow_Cover", false],
+                ["MODIS_Terra_NDSI_Snow_Cover", false]
+            ],
+            "Floods": [
+                ["Reference_Features", true],
+                ["Reference_Labels", true]
+            ],
+            "Volcanoes": [
+                ["MODIS_Terra_CorrectedReflectance_TrueColor", true],
+                ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
+                ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Fires_Terra", true],
+                ["MODIS_Fires_Aqua", false],
+                ["Reference_Features", true],
+                ["Reference_Labels", true],
+                ["VIIRS_SNPP_Fires_375m_Day", false],
+                ["VIIRS_SNPP_Fires_375m_Night", false]
+            ],
+            "Default": [
+                ["Reference_Features", true],
+                ["Reference_Labels", true],
+                ["MODIS_Terra_CorrectedReflectance_TrueColor", true],
+                ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
+                ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false]
+            ]
+          },
+          "geographic": {
             "Wildfires": [
                 ["MODIS_Terra_CorrectedReflectance_TrueColor", true],
                 ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
@@ -88,12 +168,48 @@
                 ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
                 ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false]
             ]
+          },
+          "antarctic": {
+            "Sea and Lake Ice": [
+                ["Reference_Features", true],
+                ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Terra_CorrectedReflectance_TrueColor", true],
+                ["VIIRS_SNPP_DayNightBand_ENCC", false],
+                ["MODIS_Terra_Brightness_Temp_Band31_Day", false],
+                ["MODIS_Terra_Brightness_Temp_Band31_Night", false],
+                ["MODIS_Aqua_Brightness_Temp_Band31_Day", false],
+                ["MODIS_Aqua_Brightness_Temp_Band31_Night", false],
+                ["MODIS_Aqua_Sea_Ice", false],
+                ["MODIS_Terra_Sea_Ice", false]
+            ],
+            "Severe Storms": [
+                ["Reference_Features", true],
+                ["VIIRS_SNPP_CorrectedReflectance_TrueColor", true],
+                ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Terra_CorrectedReflectance_TrueColor", false]
+            ],
+            "Snow": [
+                ["Reference_Features", true],
+                ["VIIRS_SNPP_CorrectedReflectance_TrueColor", true],
+                ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Terra_CorrectedReflectance_TrueColor", false],
+                ["MODIS_Aqua_NDSI_Snow_Cover", false],
+                ["MODIS_Terra_NDSI_Snow_Cover", false]
+            ],
+            "Default": [
+                ["Reference_Features", true],
+                ["MODIS_Terra_CorrectedReflectance_TrueColor", true],
+                ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
+                ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false]
+            ]
+          }
         },
-        "skip": [
-            "Floods",
-            "Earthquakes",
-            "Drought",
-            "Landslides"
-        ]
+          "skip": [
+              "Floods",
+              "Earthquakes",
+              "Drought",
+              "Landslides"
+          ]
     }
 }


### PR DESCRIPTION
## Description

Fixes [#564](https://github.com/nasa-gibs/worldview/issues/564) in main worldview repo.

- Add individual projections to natural events config to allow arctic and antarctic active layers based on natural events category selected

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This config change is connected to the natural events polar projections feature in the [worldview ](https://github.com/nasa-gibs/worldview)repo. See [PR#1027](https://github.com/nasa-gibs/worldview/pull/1027).

@nasa-gibs/worldview
