### PR TITLE
Remove warnings when GIBS layers are not used

### DIFF
--- a/release/config.json
+++ b/release/config.json
@@ -1,5 +1,4 @@
 {
-    "warnOnUnexpectedLayer": "true",
     "wv-options-fetch": [
         {
             "from": "https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi?request=GetCapabilities",


### PR DESCRIPTION
## Description

Fixes nasa-gibs/worldview#1038.

- Removed now unused parameter.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
