### PR TITLE
Remove grid cell value content from flood hazard metadata

### DIFF
--- a/common/config/metadata/sedac/FloodHazard.md
+++ b/common/config/metadata/sedac/FloodHazard.md
@@ -1,5 +1,5 @@
 ### Flood Hazard
-The Flood Hazard layer indicates the relative distribution and frequency of flood hazard. The information displayed in Worldview/Global Imagery Browse Services (GIBS) shows that where there are higher grid cell values, there are higher frequencies of flood occurrences between 1985 and 2003: 1-2, 3- 5-, 6-11, 12-25.
+The Flood Hazard layer indicates the relative distribution and frequency of flood hazard.
 
 Global Flood Hazard Frequency and Distribution is a 2.5 minute grid (4.5km at the equator) derived from a global listing of extreme flood events between 1985 and 2003 (poor or missing data in the early/mid 1990s) compiled by Dartmouth Flood Observatory and georeferenced to the nearest degree. The resultant flood frequency grid was then classified into 10 classes of approximately equal number of grid cells. The greater the grid cell value in the final data set, the higher the relative frequency of flood occurrence.
 

--- a/common/config/metadata/sedac/NDH_Flood_Hazard_Frequency_Distribution_1985-2003.md
+++ b/common/config/metadata/sedac/NDH_Flood_Hazard_Frequency_Distribution_1985-2003.md
@@ -1,4 +1,4 @@
-The Flood Hazard layer indicates the relative distribution and frequency of flood hazard. The information displayed in Worldview/Global Imagery Browse Services (GIBS) shows that where there are higher grid cell values, there are higher frequencies of flood occurrences between 1985 and 2003: 1-2, 3- 5-, 6-11, 12-25.
+The Flood Hazard layer indicates the relative distribution and frequency of flood hazard.
 
 Global Flood Hazard Frequency and Distribution is a 2.5 minute grid (4.5km at the equator) derived from a global listing of extreme flood events between 1985 and 2003 (poor or missing data in the early/mid 1990s) compiled by Dartmouth Flood Observatory and georeferenced to the nearest degree. The resultant flood frequency grid was then classified into 10 classes of approximately equal number of grid cells. The greater the grid cell value in the final data set, the higher the relative frequency of flood occurrence.
 


### PR DESCRIPTION
## Description

Fixes nasa-gibs/worldview#1110

Remove grid cell value content from flood hazard metadata.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

@nasa-gibs/worldview