### PR TITLE
v2.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview-options-eosdis",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -210,7 +210,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
@@ -465,7 +465,7 @@
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha1-PQJqIbf5W1cmOH1CAKwWDTcsO0g=",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
         "chardet": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview-options-eosdis",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "license": "NASA-1.3",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Technical Updates
- Remove GRUMP population count layer #226
- Updated SMAP Freeze/Thaw layer descriptions and data download #225
- Remove warnings when GIBS layers are not used #219
- Replace favicon to remove white border #218
- Remove grid cell value content from flood hazard metadata #227
- Downloads for MODIS corrected reflectance #223
- Remove about.md #221
- Add immutable palettes to Landsat_WELD_CONUS_5_Year_Tree_Cover #220

## New Layers
- Add podaac layers #224