### PR TITLE
Added data download for NRT and std OMPS layers

### DIFF
--- a/common/config/wv.json/layers/omps/OMPS_Aerosol_Index.json
+++ b/common/config/wv.json/layers/omps/OMPS_Aerosol_Index.json
@@ -10,7 +10,7 @@
             "layergroup": [
               "omps"
             ],
-            "product":  ""
+            "product":  "NMTO3"
         }
     }
 }

--- a/common/config/wv.json/layers/omps/OMPS_Ozone_Total_Column.json
+++ b/common/config/wv.json/layers/omps/OMPS_Ozone_Total_Column.json
@@ -10,7 +10,7 @@
             "layergroup": [
               "omps"
             ],
-            "product":  ""
+            "product":  "NMTO3"
         }
     }
 }

--- a/common/config/wv.json/layers/omps/OMPS_SO2_Lower_Troposphere.json
+++ b/common/config/wv.json/layers/omps/OMPS_SO2_Lower_Troposphere.json
@@ -10,7 +10,7 @@
             "layergroup": [
               "omps"
             ],
-            "product":  ""
+            "product":  "NMSO2-PCA-L2"
         }
     }
 }

--- a/common/config/wv.json/layers/omps/OMPS_SO2_Middle_Troposphere.json
+++ b/common/config/wv.json/layers/omps/OMPS_SO2_Middle_Troposphere.json
@@ -10,7 +10,7 @@
             "layergroup": [
               "omps"
             ],
-            "product":  ""
+            "product":  "NMSO2-PCA-L2"
         }
     }
 }

--- a/common/config/wv.json/layers/omps/OMPS_SO2_Planetary_Boundary_Layer.json
+++ b/common/config/wv.json/layers/omps/OMPS_SO2_Planetary_Boundary_Layer.json
@@ -10,7 +10,7 @@
             "layergroup": [
               "omps"
             ],
-            "product":  ""
+            "product":  "NMSO2-PCA-L2"
         }
     }
 }

--- a/common/config/wv.json/layers/omps/OMPS_SO2_Upper_Troposphere_and_Stratosphere.json
+++ b/common/config/wv.json/layers/omps/OMPS_SO2_Upper_Troposphere_and_Stratosphere.json
@@ -10,7 +10,7 @@
             "layergroup": [
               "omps"
             ],
-            "product":  ""
+            "product":  "NMSO2-PCA-L2"
         }
     }
 }

--- a/common/config/wv.json/products/omps/NMSO2-PCA-L2.json
+++ b/common/config/wv.json/products/omps/NMSO2-PCA-L2.json
@@ -1,0 +1,11 @@
+{
+    "products": {
+        "NMSO2-PCA-L2": {
+            "name": "OMPS/NPP PCA SO2 Total Column 1-Orbit L2 Swath 50x50km",
+            "handler": "List",
+            "query": {
+                "shortName": ["NMSO2-PCA-L2-NRT", "OMPS_NPP_NMSO2_PCA_L2"]
+            }
+        }
+    }
+}

--- a/common/config/wv.json/products/omps/NMTO3.json
+++ b/common/config/wv.json/products/omps/NMTO3.json
@@ -1,0 +1,11 @@
+{
+    "products": {
+        "NMTO3": {
+            "name": "OMPS-NPP L2 NM Ozone (O3) Total Column swath orbital",
+            "handler": "List",
+            "query": {
+                "shortName": ["OMPS_NPP_NMTO3_L2", "NMTO3NRT"]
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes nasa-gibs/worldview#1174 .

Added data download for 6 Ozone and Sulfur Dioxide OMPS layers, pointing to NRT and std shortnames.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Lint and unit tests pass locally with my changes (`npm run test`)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
