### PR TITLE
Add VIIRS Vector Fires as an option in data download

### DIFF
--- a/common/config/wv.json/layers/viirs/VIIRS_SNPP_Fires_375m_Day.json
+++ b/common/config/wv.json/layers/viirs/VIIRS_SNPP_Fires_375m_Day.json
@@ -9,7 +9,7 @@
             "layergroup": [
               "viirs"
             ],
-            "product":  "VNP14IMG_NRT_DAY",
+            "product":  ["VNP14IMG_NRT_DAY", "VNP14IMGTDL_NRT"],
             "group":    "overlays",
             "format":   "image/png",
             "period":   "daily",

--- a/common/config/wv.json/layers/viirs/VIIRS_SNPP_Fires_375m_Night.json
+++ b/common/config/wv.json/layers/viirs/VIIRS_SNPP_Fires_375m_Night.json
@@ -9,7 +9,7 @@
             "layergroup": [
               "viirs"
             ],
-            "product":  "VNP14IMG_NRT_NIGHT",
+            "product":  ["VNP14IMG_NRT_NIGHT", "VNP14IMGTDL_NRT"],
             "group":    "overlays",
             "format":   "image/png",
             "period":   "daily",

--- a/common/config/wv.json/products/viirs/VNP14IMGTDL_NRT.json
+++ b/common/config/wv.json/products/viirs/VNP14IMGTDL_NRT.json
@@ -1,0 +1,15 @@
+{
+  "products": {
+      "VNP14IMGTDL_NRT": {
+          "name": "VIIRS 375m, I-Band Active Fire Product NRT (Vector Data)",
+          "handler": "List",
+          "query": {
+              "shortName": "VNP14IMGTDL_NRT"
+          },
+          "urs": {
+              "by": "constant",
+              "value": "true"
+          }
+      }
+  }
+}


### PR DESCRIPTION
## Description

Fixes nasa-gibs/worldview#915

- add VIIRS Vector Fires as an option in data download

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
